### PR TITLE
Fix Oligo Glue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4960,7 +4960,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5375,7 +5376,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5431,6 +5433,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5474,12 +5477,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -814,8 +814,8 @@ export class Pose2D extends ContainerObject implements Updatable {
     }
 
     public toggleDesignStruct(seqnum: number): boolean {
-        if (this._designStruct.length !== this._sequence.length) {
-            this._designStruct = new Array(this._sequence.length);
+        if (this._designStruct.length !== this.fullSequenceLength) {
+            this._designStruct = new Array(this.fullSequenceLength);
         }
 
         this._designStruct[seqnum] = !this._designStruct[seqnum];


### PR DESCRIPTION
The array created to store the glue data was the size of the main strand, instead of the full sequence.