### PR TITLE
Change N to A and T to U and ignore spaces when pasting a sequence

### DIFF
--- a/src/eterna/ui/PasteSequenceDialog.ts
+++ b/src/eterna/ui/PasteSequenceDialog.ts
@@ -36,9 +36,9 @@ export default class PasteSequenceDialog extends Dialog<number[]> {
     }
 
     private onSequenceEntered(sequence: string): void {
-        sequence = sequence.toUpperCase();
+        sequence = sequence.toUpperCase().replace(/T/g, 'U');
         // make paste entry robust to blanks, and allow index specification after sequence.
-        let seq = sequence.split(' ')[0].replace(/T/g, "U");;
+        let seq = sequence.split(' ')[0];
         for (const char of seq) {
             if (char !== 'A' && char !== 'U' && char !== 'G' && char !== 'C') {
                 (this.mode as GameMode).showNotification('You can only use characters A, C, G, T, and U');


### PR DESCRIPTION
Per Michael's request.
While T->U is a given, I am not 100% sure about removing spaces and changing N to A.
Isn't there an argument for having N or space still be counted, but having them not change the sequence?
I could potentially see IUPAC strings being used to "mask" the RNA - for example, you could potentially save a sequence, and put some N holes in it, so that after you finish writing a sequence that for example satisfies the other state, you would pop the sequence mask and combine the two sequences.
However, I think it would be too niche to really deserve functionality outside of a booster, so N->A probably won't be problematic.