### PR TITLE
Load screen blurbs!

### DIFF
--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -129,7 +129,7 @@ export class EternaApp extends FlashbangApp {
         Eterna.chat = new ChatManager(this._params.chatboxID, Eterna.settings);
         Eterna.gameDiv = document.getElementById(this._params.containerID);
 
-        this.setLoadingText("Authenticating...", this.getExtraBlurb());
+        this.setLoadingText("Authenticating...");
 
         this.authenticate()
             .then(() => {
@@ -357,32 +357,6 @@ export class EternaApp extends FlashbangApp {
             this._modeStack.pushMode(new LoadingMode(text, extraBlurbText));
         }
     }
-
-    // FIXME: This probably belongs in the backend database to allow for easy updating
-    //  and reweighting by message importance without requiring code updates -- rhiju.
-    private getExtraBlurb(): string {
-        var ExtraBlurbs = [
-            "Developed by players for players",
-            "Afraid of pandemic flu? Stay calm and play Eterna.",
-            "Played by Humans, Scored by Nature.",
-            "Empowering citizen scientists to invent medicine",
-            "Heard of CRISPR? That's medicine based on designed RNA",
-            "The only videogame with real experiments in the loop",
-            "No computer can solve the entire Eterna100",
-            "Player-made bot NEMO crushes deep learning.",
-            "Twenty scientific publications and counting...",
-            "Top Eterna players still crush all bots.",
-            "Science is much more about the questions than the facts",
-            "Citizen science works because we are a curious species.",
-            "Just hang in there and you will eventually get the hang of it.",
-            "The ribosome makes life. You can re-design it.",
-            "The first treatment for spinal muscular atrophy is RNA",
-            //"RNA design is provably intractable for computers."
-        ]
-        return ExtraBlurbs[Math.floor(Math.random() * ExtraBlurbs.length)];
-    }
-
-
 
     private popLoadingMode(): void {
         if (this._modeStack.topMode instanceof LoadingMode) {

--- a/src/eterna/mode/LoadingMode.ts
+++ b/src/eterna/mode/LoadingMode.ts
@@ -17,7 +17,7 @@ export class LoadingMode extends AppMode {
     public constructor(text: string, extraBlurbText: string ) {
         super();
         this._text = text;
-        this._extraBlurbText = extraBlurbText;
+        if ( extraBlurbText == null ) this._extraBlurbText = this.getExtraBlurb();
     }
 
     public get isOpaque(): boolean { return true; }
@@ -42,13 +42,13 @@ export class LoadingMode extends AppMode {
 
         this.addObject(new Background(0), this._container);
 
-        this._textField = Fonts.arial(this._text, 30).color(0xffffff).build();
+        this._textField = Fonts.arial(this._text, 24).color(0xffffff).build();
         this._textField.x = -this._textField.width * 0.5;
         this._textField.y = -this._textField.height * 0.5;
 
-        this._extraBlurbTextField = Fonts.arial(this._extraBlurbText, 36).bold().color(0xffffff).build();
+        this._extraBlurbTextField = Fonts.arial(this._extraBlurbText, 36).bold().color(0xffffff).hAlignCenter().build();
         this._extraBlurbTextField.x = -this._extraBlurbTextField.width * 0.5;
-        this._extraBlurbTextField.y = -this._extraBlurbTextField.height * 1.6;
+        this._extraBlurbTextField.y = -this._textField.height - this._extraBlurbTextField.height;
 
         let container = new ContainerObject();
         container.container.addChild(this._textField);
@@ -58,7 +58,7 @@ export class LoadingMode extends AppMode {
         container.addObject(new SerialTask(
             new DelayTask(0.5),
             new RepeatingTask((): ObjectTask => new SerialTask(
-                new ScaleTask(0.9, 0.9, 1, Easing.easeInOut),
+                new ScaleTask(0.95, 0.95, 1, Easing.easeInOut),
                 new ScaleTask(1, 1, 1, Easing.easeInOut)
             ))
         ));
@@ -80,6 +80,32 @@ export class LoadingMode extends AppMode {
         Eterna.chat.popHideChat();
         super.exit();
     }
+
+    private getExtraBlurb(): string {
+        var ExtraBlurbs = [
+            "A good scientist will tell you that being wrong can\nbe just as interesting as being right.",
+            "Developed by players for players",
+            "Afraid of pandemic flu? Stay calm and play Eterna.",
+            "Played by Humans, Scored by Nature.",
+            "Empowering citizen scientists to invent medicine",
+            "Heard of CRISPR therapies? That's RNA medicine",
+            "The only videogame with real experiments in the loop",
+            "No computer can solve the entire Eterna100",
+            "Player-made bot NEMO crushes deep learning.",
+            "Twenty scientific publications and counting...",
+            "Top Eterna players still crush all bots.",
+            "Science is much more about the\nquestions than the facts",
+            "Citizen science works because\nwe are a curious species.",
+            "Just hang in there and you will eventually\nget the hang of it.",
+            "The ribosome makes life. You can re-design it.",
+            "First treatment for spinal muscular atrophy is RNA",
+//           "RNA design is provably intractable for computers.",
+//            "Beware this game is addicting...\n...at least this addiction is for a noble cause.\n     -- Eterna player hoglahoo",
+]
+        return ExtraBlurbs[Math.floor(Math.random() * ExtraBlurbs.length)];
+    }
+
+
 
     private _text: string;
     private _textField: Text;


### PR DESCRIPTION
Current load screen totally sucks, especially for any new players who are clicking in from front page  -- it even displays the puzzle ID number, which is totally cryptic and off-putting.   And there's a huge opportunity here to convey the 'Eterna spirit' and information about how awesome this game is.

Got rid of puzzle ID number, and put in short blurbs  about Eterna (selected at random). Like "Played by Humans, Scored by Nature", and teasers about ribosomes, CRISPR, vaccines. Blurbs are based on some notes I've been taking, and some discussion with Eli Fisker.

These blurbs are currently hardcoded into `EternaJS` but probably a 1-hour crash session with the other devs would let us install blurb editing into the database. That would allow us to, for example, put important news (like EternaCon) into the load screen blurbs. Could also imagine putting banner .png's into the load screen. Both would go into future PR's.

