### PR TITLE
fix highlight box strangely sharp corners

### DIFF
--- a/src/eterna/pose2D/HighlightBox.ts
+++ b/src/eterna/pose2D/HighlightBox.ts
@@ -7,7 +7,6 @@ import {AlphaTask} from "../../flashbang/tasks/AlphaTask";
 import {RepeatingTask} from "../../flashbang/tasks/RepeatingTask";
 import {SerialTask} from "../../flashbang/tasks/SerialTask";
 import {Pose2D} from "./Pose2D";
-import { access } from "fs";
 
 export enum HighlightType {
     STACK = 0,


### PR DESCRIPTION
Fix bug (choice?) in how highlight boxes are rendered.  Some acute corners get exacerbated as we move to posisbility of user-defined layours.

Used to get some sharp corners
<img width="511" alt="Screen Shot 2019-09-23 at 1 16 32 PM" src="https://user-images.githubusercontent.com/1672331/65459475-d7025300-de04-11e9-80c9-3e5643b79d7a.png">
Now highlight boxes always have square corners:

<img width="532" alt="Screen Shot 2019-09-23 at 1 18 03 PM" src="https://user-images.githubusercontent.com/1672331/65459512-f39e8b00-de04-11e9-9ce4-9498c236198e.png">

To discuss: 
 - Use cubic interpolation to make smoothed highilght boxes -- working out how to do this.
 - make these boxes blend a bit into rest of drawing with some rendering/blending tricks.
Above will incur some penalty in rendering graphics -- need to discuss/measure how much this is compared to rendering bitmaps for bases.