### PR TITLE
hotfix.  non-native stacked pairs were being accidentally rendered in customLayout

### DIFF
--- a/src/eterna/pose2D/RNALayout.ts
+++ b/src/eterna/pose2D/RNALayout.ts
@@ -617,6 +617,14 @@ export default class RNALayout {
                 return false;
             }
         }
+
+        if (rootnode && rootnode.isPair) {
+            // is initial pair of a stacked pair also paired in target structure?
+            if (this._targetPairs[rootnode.indexA] !== rootnode.indexB) {
+                return false;
+            }
+        }
+
         if (rootnode.children.length === 1 && rootnode.children[0].indexA < 0) return false;
 
         for (let ii = 0; ii < rootnode.children.length; ii++) {


### PR DESCRIPTION
example from a 16S rRNA "h44" puzzle on dev server:
<img width="211" alt="Screen Shot 2019-12-19 at 11 08 09 AM" src="https://user-images.githubusercontent.com/1672331/71218163-591fdd80-2275-11ea-8143-5c6dfe689f29.png">
fix was simple enough