### PR TITLE
Update to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7209,7 +7209,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
This  change generated by "npm install" command, updates URL for webpack to use `https:` rather than `http:`