### PR TITLE
Fix BitmapManager caching to account for color

### DIFF
--- a/src/eterna/resources/BitmapManager.ts
+++ b/src/eterna/resources/BitmapManager.ts
@@ -25,18 +25,25 @@ export default class BitmapManager {
     private static getTextBitmapImpl(
         text: string, fontName: string, fontSize: number, bold: boolean, color: number
     ): Texture {
-        let bitmap: Texture = BitmapManager._textBitmaps.get(text);
+        const styleString = [fontName, fontSize, bold, color].join(',');
+        let textMap = BitmapManager._textBitmaps.get(styleString);
+        if (textMap == null) {
+            textMap = new Map();
+            BitmapManager._textBitmaps.set(styleString, textMap);
+        }
+
+        let bitmap: Texture = textMap.get(text);
         if (bitmap == null) {
             let builder = new TextBuilder(text).font(fontName).fontSize(fontSize).color(color);
             if (bold) {
                 builder.bold();
             }
             bitmap = TextureUtil.renderToTexture(builder.build());
-            BitmapManager._textBitmaps.set(text, bitmap);
+            textMap.set(text, bitmap);
         }
 
         return bitmap;
     }
 
-    private static readonly _textBitmaps: Map<string, Texture> = new Map();
+    private static readonly _textBitmaps: Map<string, Map<string, Texture>> = new Map();
 }


### PR DESCRIPTION
Caching Textures in BitmapManager did not account for attributes like font, size, color or bold, resulting in sometimes inconsistent text color.  E.g. under some circumstances base numbers might show up in red, rather than white.

Fixes: #69 
Fixes: #185

Minor note: branch name I used was fix_29 rather than the more logical fix_69.  