### PR TITLE
fix build on ubuntu

### DIFF
--- a/multiplatform/mkdirp.js
+++ b/multiplatform/mkdirp.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 
 for (path of process.argv.slice(2)) {
-    fs.mkdirSync(path, { recursive: true });
+    if (!fs.existsSync(path)) {
+        fs.mkdirSync(path, { recursive: true });
+    }
 }


### PR DESCRIPTION
mkDirSync() fails on ubuntu, when the target directory already exists.