### PR TITLE
Support Puzzle Switching

### DIFF
--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -28,6 +28,7 @@ import FolderManager from './folding/FolderManager';
 import LinearFoldC from './folding/LinearFoldC';
 import LinearFoldV from './folding/LinearFoldV';
 import Folder from './folding/Folder';
+import RSignals from './rscript/RSignals';
 
 enum PuzzleID {
     FunAndEasy = 4350940,
@@ -116,6 +117,13 @@ export default class EternaApp extends FlashbangApp {
         eternaContainer.appendChild(overlay);
 
         ExternalInterface.init(eternaContainer);
+
+        RSignals.pushPuzzle.connect(async (puzzleId) => {
+            const puzzle = await PuzzleManager.instance.getPuzzleByID(puzzleId);
+            this._modeStack.pushMode(new PoseEditMode(puzzle, {}));
+        });
+
+        RSignals.popPuzzle.connect(() => this._modeStack.popMode());
     }
 
     /* override */

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1161,6 +1161,11 @@ export default class PoseEditMode extends GameMode {
 
     public showMissionScreen(doShow: boolean): void {
         this._showMissionScreen = doShow;
+        if (doShow) {
+            if (this._isPlaying) {
+                this.showIntroScreen();
+            }
+        }
     }
 
     public showConstraints(doShow: boolean): void {

--- a/src/eterna/puzzle/PuzzleManager.ts
+++ b/src/eterna/puzzle/PuzzleManager.ts
@@ -358,6 +358,13 @@ export default class PuzzleManager {
             puzzle.constraints.filter(isScriptConstraint)
                 .map((scriptConstraint) => ExternalInterface.preloadScript(scriptConstraint.scriptID))
         );
+
+        // Pre-load secondary puzzle
+        const [m, secondaryPuzzleId] = puzzle.rscript.match(/#PRE-PushPuzzle ([0-9]+);/) ?? [null, null];
+        if (secondaryPuzzleId) {
+            await this.getPuzzleByID(parseInt(secondaryPuzzleId, 10));
+        }
+
         log.info(`Loaded puzzle [name=${puzzle.getName()}]`);
         return puzzle;
     }

--- a/src/eterna/rscript/RNAScript.ts
+++ b/src/eterna/rscript/RNAScript.ts
@@ -10,6 +10,8 @@ import ROPWait, {ROPWaitType} from './ROPWait';
 import RScriptEnv from './RScriptEnv';
 import RScriptOp from './RScriptOp';
 import RScriptOpTree from './RScriptOpTree';
+import ROPPopPuzzle from './ROPPopPuzzle';
+import ROPShowMissionScreen from './ROPShowMissionScreen';
 
 export default class RNAScript {
     constructor(puz: Puzzle, ui: PoseEditMode) {
@@ -99,6 +101,8 @@ export default class RNAScript {
         let waitRegex = /WaitFor(.*)/ig;
         let preRegex = /#PRE-(.*)/g;
         let rnaRegex = /^RNA(SetBase|ChangeMode|EnableModification|SetPainter|ChangeState|SetZoom|SetPIP)$/ig;
+        const popPuzzle = /PopPuzzle/;
+        const showMissionScreen = /ShowMissionScreen/;
 
         let regResult: any[];
         if ((regResult = preRegex.exec(op)) != null) {
@@ -145,6 +149,10 @@ export default class RNAScript {
         } else if ((regResult = rnaRegex.exec(op))) {
             let ropRNAType: ROPRNAType = regResult[1].toUpperCase();
             return new ROPRNA(ropRNAType, this._env);
+        } else if ((regResult = popPuzzle.exec(op))) {
+            return new ROPPopPuzzle();
+        } else if ((regResult = showMissionScreen.exec(op))) {
+            return new ROPShowMissionScreen(JSON.parse(args), this._env);
         }
         // Shouldn't reach here ever.
         throw new Error(`Invalid operation: ${op}`);

--- a/src/eterna/rscript/RNAScript.ts
+++ b/src/eterna/rscript/RNAScript.ts
@@ -20,7 +20,6 @@ export default class RNAScript {
         this._env = new RScriptEnv(ui, puz);
         ui.addObject(this._env, ui.container);
 
-        ROPWait.clearRopWait();
         this._ops = new RScriptOpTree();
 
         // Convert string into instructions by splitting at semicolons.
@@ -39,6 +38,7 @@ export default class RNAScript {
     /** Notify us when RNA is completed (or puzzle finishes). */
     public finishLevel(): void {
         ROPWait.notifyFinishRNA();
+        ROPWait.clearRopWait();
         if (this._env) {
             this._env.cleanup();
         }

--- a/src/eterna/rscript/RNAScript.ts
+++ b/src/eterna/rscript/RNAScript.ts
@@ -150,9 +150,9 @@ export default class RNAScript {
             let ropRNAType: ROPRNAType = regResult[1].toUpperCase();
             return new ROPRNA(ropRNAType, this._env);
         } else if ((regResult = popPuzzle.exec(op))) {
-            return new ROPPopPuzzle();
+            return new ROPPopPuzzle(this._env);
         } else if ((regResult = showMissionScreen.exec(op))) {
-            return new ROPShowMissionScreen(JSON.parse(args), this._env);
+            return new ROPShowMissionScreen(this._env);
         }
         // Shouldn't reach here ever.
         throw new Error(`Invalid operation: ${op}`);

--- a/src/eterna/rscript/ROPPopPuzzle.ts
+++ b/src/eterna/rscript/ROPPopPuzzle.ts
@@ -1,10 +1,12 @@
 import RScriptOp from './RScriptOp';
 import RSignals from './RSignals';
+import RScriptEnv from './RScriptEnv';
 
 export default class ROPPopPuzzle extends RScriptOp {
-    constructor() {
-        // tslint:disable-next-line
-        super({} as any);
+
+    // eslint-disable no-useless-constructor
+    constructor(env: RScriptEnv) {
+        super(env);
     }
 
     public exec(): void {

--- a/src/eterna/rscript/ROPPopPuzzle.ts
+++ b/src/eterna/rscript/ROPPopPuzzle.ts
@@ -3,7 +3,7 @@ import RSignals from './RSignals';
 import RScriptEnv from './RScriptEnv';
 
 export default class ROPPopPuzzle extends RScriptOp {
-
+    // eslint-disable-next-line no-useless-constructor
     constructor(env: RScriptEnv) {
         super(env);
     }

--- a/src/eterna/rscript/ROPPopPuzzle.ts
+++ b/src/eterna/rscript/ROPPopPuzzle.ts
@@ -1,0 +1,13 @@
+import RScriptOp from './RScriptOp';
+import RSignals from './RSignals';
+
+export default class ROPPopPuzzle extends RScriptOp {
+    constructor() {
+        // tslint:disable-next-line
+        super({} as any);
+    }
+
+    public exec(): void {
+        RSignals.popPuzzle.emit();
+    }
+}

--- a/src/eterna/rscript/ROPPopPuzzle.ts
+++ b/src/eterna/rscript/ROPPopPuzzle.ts
@@ -4,7 +4,6 @@ import RScriptEnv from './RScriptEnv';
 
 export default class ROPPopPuzzle extends RScriptOp {
 
-    // eslint-disable no-useless-constructor
     constructor(env: RScriptEnv) {
         super(env);
     }

--- a/src/eterna/rscript/ROPPre.ts
+++ b/src/eterna/rscript/ROPPre.ts
@@ -1,6 +1,7 @@
 import {PoseState} from 'eterna/puzzle/Puzzle';
 import RScriptEnv from './RScriptEnv';
 import RScriptOp from './RScriptOp';
+import RSignals from './RSignals';
 
 enum ROPPreType {
     DISABLE_MISSION_SCREEN = 'DISABLE_MISSION_SCREEN',
@@ -10,6 +11,7 @@ enum ROPPreType {
     DISABLE_UI_ELEMENT = 'DISABLE_UI_ELEMENT',
     DISABLE_RNA_CHANGE = 'DISABLE_RNA_CHANGE',
     SET_DEFAULT_FOLD_MODE = 'SET_DEFAULT_FOLD_MODE',
+    PUSH_PUZZLE = 'PUSH_PUZZLE'
 }
 
 export default class ROPPre extends RScriptOp {
@@ -24,6 +26,7 @@ export default class ROPPre extends RScriptOp {
         const hideUIRegex = /(Hide|Show|Disable|Enable)UI/ig;
         const disableRNAMod = /(DisableRNAModification)/ig;
         const modeRegex = /^(Native|Target)Mode$/ig;
+        const pushPuzzleRegex = /PushPuzzle/;
 
         let regResult: RegExpExecArray;
         if ((regResult = disMissionScreenRegex.exec(command)) != null) {
@@ -43,6 +46,8 @@ export default class ROPPre extends RScriptOp {
         } else if ((regResult = modeRegex.exec(command)) != null) {
             this._type = ROPPreType.SET_DEFAULT_FOLD_MODE;
             this._foldMode = (regResult[1].toUpperCase() === 'NATIVE' ? PoseState.NATIVE : PoseState.TARGET);
+        } else if ((regResult = pushPuzzleRegex.exec(command)) != null) {
+            this._type = ROPPreType.PUSH_PUZZLE;
         }
     }
 
@@ -97,6 +102,12 @@ export default class ROPPre extends RScriptOp {
                 break;
             case ROPPreType.SET_DEFAULT_FOLD_MODE:
                 this._env.puzzle.defaultMode = this._foldMode;
+                break;
+
+            case ROPPreType.PUSH_PUZZLE: {
+                const puzzleId = parseInt(this._allArgs[0], 10);
+                RSignals.pushPuzzle.emit(puzzleId);
+            }
                 break;
             default:
                 throw new Error(`Invalid Preprocessing Command: ${this._type}`);

--- a/src/eterna/rscript/ROPShowMissionScreen.ts
+++ b/src/eterna/rscript/ROPShowMissionScreen.ts
@@ -2,6 +2,7 @@ import RScriptOp from './RScriptOp';
 import RScriptEnv from './RScriptEnv';
 
 export default class ROPShowMissionScreen extends RScriptOp {
+    // eslint-disable-next-line no-useless-constructor
     constructor(env: RScriptEnv) {
         super(env);
     }

--- a/src/eterna/rscript/ROPShowMissionScreen.ts
+++ b/src/eterna/rscript/ROPShowMissionScreen.ts
@@ -1,0 +1,15 @@
+import RScriptOp from './RScriptOp';
+import RScriptEnv from './RScriptEnv';
+
+export default class ROPShowMissionScreen extends RScriptOp {
+    private _show: boolean;
+
+    constructor(show: boolean, env: RScriptEnv) {
+        super(env);
+        this._show = show;
+    }
+
+    public exec(): void {
+        this._env.ui.showMissionScreen(this._show);
+    }
+}

--- a/src/eterna/rscript/ROPShowMissionScreen.ts
+++ b/src/eterna/rscript/ROPShowMissionScreen.ts
@@ -2,14 +2,11 @@ import RScriptOp from './RScriptOp';
 import RScriptEnv from './RScriptEnv';
 
 export default class ROPShowMissionScreen extends RScriptOp {
-    private _show: boolean;
-
-    constructor(show: boolean, env: RScriptEnv) {
+    constructor(env: RScriptEnv) {
         super(env);
-        this._show = show;
     }
 
     public exec(): void {
-        this._env.ui.showMissionScreen(this._show);
+        this._env.ui.showMissionScreen(true);
     }
 }

--- a/src/eterna/rscript/RSignals.ts
+++ b/src/eterna/rscript/RSignals.ts
@@ -1,0 +1,6 @@
+import {Signal, UnitSignal} from 'signals';
+
+export default class RSignals {
+    public static pushPuzzle = new Signal<number>();
+    public static popPuzzle = new UnitSignal();
+}


### PR DESCRIPTION
Can be done using the following tools:
`PRE-PushPuzzle` directive
`PopPuzzle` command (to call from the second puzzle, to go back to the main puzzle)
`ShowMissionScreen` command
**Testable with Puzzle `9386663` on Eterna-dev**

resolves #253 