### PR TITLE
Fix positioning of highlight on certain UI elements

### DIFF
--- a/src/eterna/rscript/RScriptUIElement.ts
+++ b/src/eterna/rscript/RScriptUIElement.ts
@@ -7,8 +7,8 @@ export function GetRScriptUIElementBounds(element: RScriptUIElement): Rectangle 
     if (element instanceof GameObject) {
         return element.display != null
             ? new Rectangle(
-                element.display.x,
-                element.display.y,
+                element.display.worldTransform.tx,
+                element.display.worldTransform.ty,
                 DisplayUtil.width(element.display),
                 DisplayUtil.height(element.display)
             )


### PR DESCRIPTION
Nucleotide palette highlight was misplaced because it used the local position instead of the world position of the target.

Needed by [Nova Tutorial 1.1](https://www.pbs.org/wgbh/nova/labs//lab/rna/research#/nceg/1/1) / Eterna-dev puzzle `9386588`