### PR TITLE
Energy Scores Fixes & Improvements

### DIFF
--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -449,6 +449,15 @@ export default class Pose2D extends ContainerObject implements Updatable {
         return out;
     }
 
+    public getEnergyScorePos(index: number, out: Point = null): Point {
+        if (out === null) {
+            out = new Point();
+        }
+        out.x = this._scoreTexts[index].x;
+        out.y = this._scoreTexts[index].y;
+        return out;
+    }
+
     public getBaseOutXY(seq: number, out: Point = null): Point {
         out = this._bases[seq].getOutXY(out);
         out.x += this._offX;

--- a/src/eterna/rscript/RNAScript.ts
+++ b/src/eterna/rscript/RNAScript.ts
@@ -92,7 +92,7 @@ export default class RNAScript {
         op = op.replace(/\s*$/, '');
 
         // Regex to detect the various commands
-        let textboxRegex = /(Show|Hide)(Textbox|Arrow)(Location|Nucleotide)?/ig;
+        let textboxRegex = /(Show|Hide)(Textbox|Arrow)(Location|Nucleotide|Energy)?/ig;
         let highlightRegex = /(Show|Hide)(UI)?Highlight/ig;
         let uiRegex = /(Show|Hide|Enable|Disable)UI$/ig;
         let hintRegex = /(Show|Hide)(Paint)?Hint/ig;
@@ -111,9 +111,19 @@ export default class RNAScript {
             let textboxMode: ROPTextboxMode;
             if (regResult[2].toUpperCase() === 'ARROW') {
                 if (regResult[3]) {
-                    textboxMode = regResult[3].toUpperCase() === 'LOCATION'
-                        ? ROPTextboxMode.ARROW_LOCATION
-                        : ROPTextboxMode.ARROW_NUCLEOTIDE;
+                    switch (regResult[3].toUpperCase()) {
+                        case 'LOCATION':
+                            textboxMode = ROPTextboxMode.ARROW_LOCATION;
+                            break;
+                        case 'NUCLEOTIDE':
+                            textboxMode = ROPTextboxMode.ARROW_NUCLEOTIDE;
+                            break;
+                        case 'ENERGY':
+                            textboxMode = ROPTextboxMode.ARROW_ENERGY;
+                            break;
+                        default:
+                            throw new Error(`Invalid arrow type: ${regResult[3]}`);
+                    }
                 } else {
                     textboxMode = ROPTextboxMode.ARROW_DEFAULT;
                 }

--- a/src/eterna/rscript/ROPHighlight.ts
+++ b/src/eterna/rscript/ROPHighlight.ts
@@ -32,6 +32,11 @@ export default class ROPHighlight extends RScriptOp {
 
     /* override */
     public exec(): void {
+        if (this._uiElementString?.toUpperCase() === RScriptUIElementID.ENERGY) {
+            this._env.pose.showEnergyHighlight = this._opVisible;
+            return;
+        }
+
         // Remove highlight with ID.
         if (this._env.hasVar(this._id)) {
             let existing: any = this._env.getVar(this._id);

--- a/src/eterna/rscript/ROPTextbox.ts
+++ b/src/eterna/rscript/ROPTextbox.ts
@@ -18,6 +18,7 @@ export enum ROPTextboxMode {
     TEXTBOX_DEFAULT = 'TEXTBOX_DEFAULT',
     ARROW_LOCATION = 'ARROW_LOCATION',
     ARROW_NUCLEOTIDE = 'ARROW_NUCLEOTIDE',
+    ARROW_ENERGY = 'ARROW_ENERGY',
     ARROW_DEFAULT = 'ARROW_DEFAULT',
 }
 
@@ -87,7 +88,7 @@ export default class ROPTextbox extends RScriptOp {
                 );
             } else if (this._mode === ROPTextboxMode.TEXTBOX_NUCLEOTIDE) {
                 // Get position of the textbox based on position of the nucleotide.
-                let p: Point = this._env.pose.getBaseLoc(this._nucIdx);
+                let p: Point = this._env.pose.getBaseLoc(this._targetIndex);
                 let offset = new Point(ROPTextbox.DEFAULT_X_OFFSET, -(textBox.container.height * 0.5) - 10);
                 if (this._hasXOffset) {
                     offset.x = this._xOffset;
@@ -98,7 +99,7 @@ export default class ROPTextbox extends RScriptOp {
                 }
 
                 textBox.display.position = new Point(p.x + offset.x, p.y + offset.y);
-                this._env.pose.addAnchoredObject(new RNAAnchorObject(textBox, this._nucIdx, offset));
+                this._env.pose.addAnchoredObject(new RNAAnchorObject(textBox, this._targetIndex, offset));
             } else if (this._mode === ROPTextboxMode.TEXTBOX_DEFAULT) {
                 this._env.setTextboxVisible(this._id, true);
             }
@@ -133,7 +134,9 @@ export default class ROPTextbox extends RScriptOp {
                     Flashbang.stageHeight * this._yPos + this._yRel
                 );
             } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
-                newArrow.display.position = this._env.pose.getBaseLoc(this._nucIdx);
+                newArrow.display.position = this._env.pose.getBaseLoc(this._targetIndex);
+            } else if (this._mode === ROPTextboxMode.ARROW_ENERGY) {
+                newArrow.display.position = this._env.pose.getEnergyScorePos(this._targetIndex);
             }
 
             // Determine where we want to draw the tip of the arrow
@@ -180,8 +183,8 @@ export default class ROPTextbox extends RScriptOp {
             newArrow.baseLength = this._arrowLength;
             newArrow.redrawIfDirty();
 
-            if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
-                let offset = new Vector2();
+            const calcOffset = () => {
+                const offset = new Vector2();
                 offset.x = Math.cos((this._arrowRotation * Math.PI) / 180);
                 offset.y = Math.sin((this._arrowRotation * Math.PI) / 180);
                 if (!this._hasXOffset) {
@@ -189,11 +192,23 @@ export default class ROPTextbox extends RScriptOp {
                 } else {
                     offset.length = this._xOffset;
                 }
-                let p = this._env.pose.getBaseLoc(this._nucIdx);
+                return offset;
+            };
+
+            if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                const offset = calcOffset();
+                const p = this._env.pose.getBaseLoc(this._targetIndex);
                 newArrow.display.position = new Point(p.x + offset.x, p.y + offset.y);
                 log.debug('TODO: set_anchor_nucleotide?');
                 // TSC - I'm not sure if this is ever called or what it should do
                 // newArrow.set_anchor_nucleotide(this._env.GetRNA(), this._nuc_idx, offset.x, offset.y);
+            } else if (this._mode === ROPTextboxMode.ARROW_ENERGY) {
+                const offset = calcOffset();
+                const p = this._env.pose.getEnergyScorePos(this._targetIndex);
+                newArrow.display.position = new Point(
+                    p.x + offset.x + ROPTextbox.DEFAULT_ENERGY_ARROW_OFFSET.x,
+                    p.y + offset.y + ROPTextbox.DEFAULT_ENERGY_ARROW_OFFSET.y
+                );
             }
         };
 
@@ -248,8 +263,13 @@ export default class ROPTextbox extends RScriptOp {
                     } else {
                         this._xPos = Number(arg);
                     }
-                } else if (this._show && this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
-                    this._nucIdx = Number(arg) - 1;
+                } else if (this._show
+                    && (
+                        this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                        || this._mode === ROPTextboxMode.ARROW_ENERGY
+                    )
+                ) {
+                    this._targetIndex = Number(arg) - 1;
                 } else {
                     this._id = this._env.getStringRef(arg);
                 }
@@ -269,10 +289,13 @@ export default class ROPTextbox extends RScriptOp {
                     } else {
                         this._yPos = Number(arg);
                     }
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._id = this._env.getStringRef(arg);
                 } else {
-                    this._nucIdx = Number(arg) - 1;
+                    this._targetIndex = Number(arg) - 1;
                 }
                 break;
             case 2: // Y in mode 0. Title in mode 1.
@@ -296,7 +319,10 @@ export default class ROPTextbox extends RScriptOp {
                     this._title = this._env.getStringRef(arg);
                 } else if (this._mode === ROPTextboxMode.ARROW_LOCATION) {
                     this._arrowRotation = Number(arg);
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._arrowLength = Number(arg);
                 } else {
                     this._id = this._env.getStringRef(arg);
@@ -307,7 +333,10 @@ export default class ROPTextbox extends RScriptOp {
                     this._id = this._env.getStringRef(arg);
                 } else if (this._mode === ROPTextboxMode.ARROW_LOCATION) {
                     this._arrowLength = Number(arg);
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._myWidth = Number(arg);
                 } else {
                     this._buttonText = this._env.getStringRef(arg);
@@ -318,7 +347,10 @@ export default class ROPTextbox extends RScriptOp {
                     this._buttonText = this._env.getStringRef(arg);
                 } else if (this._mode === ROPTextboxMode.ARROW_LOCATION) {
                     this._myWidth = Number(arg);
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._hasParent = ROPTextbox.parseBool(arg);
                 } else {
                     this._initialShow = ROPTextbox.parseBool(arg);
@@ -327,7 +359,10 @@ export default class ROPTextbox extends RScriptOp {
             case 6:
                 if (this._mode === ROPTextboxMode.ARROW_LOCATION) {
                     this._hasParent = ROPTextbox.parseBool(arg);
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._parentID = this._env.getStringRef(arg);
                 } else if (this._mode === ROPTextboxMode.TEXTBOX_NUCLEOTIDE) {
                     this._fixedSize = ROPTextbox.parseBool(arg);
@@ -338,7 +373,10 @@ export default class ROPTextbox extends RScriptOp {
             case 7:
                 if (this._mode === ROPTextboxMode.ARROW_LOCATION) {
                     this._parentID = this._env.getStringRef(arg);
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._fillColor = ColorUtil.fromString(`#${this._env.getStringRef(arg)}`);
                 } else if (this._mode === ROPTextboxMode.TEXTBOX_LOCATION) {
                     this._fixedSize = ROPTextbox.parseBool(arg);
@@ -362,7 +400,10 @@ export default class ROPTextbox extends RScriptOp {
                 if (this._mode === ROPTextboxMode.TEXTBOX_NUCLEOTIDE) {
                     this._hasYOffset = true;
                     this._yOffset = Number(arg);
-                } else if (this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE) {
+                } else if (
+                    this._mode === ROPTextboxMode.ARROW_NUCLEOTIDE
+                    || this._mode === ROPTextboxMode.ARROW_ENERGY
+                ) {
                     this._hasXOffset = true;
                     this._xOffset = Number(arg);
                 } else {
@@ -431,7 +472,7 @@ export default class ROPTextbox extends RScriptOp {
     private _yPos: number = 0;
     private _xRel: number = 0;
     private _yRel: number = 0;
-    private _nucIdx: number = 0;
+    private _targetIndex: number = 0;
     private _id: string = '';
     private _buttonText: string = 'Next';
     private _initialShow: boolean = true;
@@ -453,6 +494,7 @@ export default class ROPTextbox extends RScriptOp {
 
     private static readonly DEFAULT_X_OFFSET = 35;
     private static readonly DEFAULT_ARROW_OFFSET = 12;
+    private static readonly DEFAULT_ENERGY_ARROW_OFFSET = new Point(15, 7);
 
     private static readonly STD_RED_COLOR = 'F85F00';
     private static readonly STD_BLUE_COLOR = '00BFF9';


### PR DESCRIPTION
`ShowArrowEnergy` command for making arrows point to an energy score.
Support highlighting of energy scores.
Needed by [Nova Tutorial 4.1](https://www.pbs.org/wgbh/nova/labs//lab/rna/research#/nceg/4/1) / Eterna-dev puzzle `9386710`