### PR TITLE
Make RNA of 4 or less nucleotides straight instead of circular

### DIFF
--- a/src/eterna/pose2D/RNALayout.ts
+++ b/src/eterna/pose2D/RNALayout.ts
@@ -170,7 +170,7 @@ export default class RNALayout {
         // After that, start making a circle.
         if (this._root != null) {
             this.getCoordsRecursive(this._root, xarray, yarray);
-        } else if (xarray.length < 3) {
+        } else if (xarray.length <= 4) {
             // there is no structure (no pairs)
             // really short, just place them in a vertical line
             for (let ii = 0; ii < xarray.length; ii++) {


### PR DESCRIPTION
If 4 or less nucleotides, display a straight RNA instead of a circle.

Needed by [Nova Tutorial 1.1](https://www.pbs.org/wgbh/nova/labs//lab/rna/research#/nceg/1/1) / Eterna-dev `9386588`