### PR TITLE
Nucleotide range selector

### DIFF
--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -1921,8 +1921,10 @@ export default class Pose2D extends ContainerObject implements Updatable {
         let center: Point;
 
         // Hide bases that aren't part of our current sequence
-        for (let ii = 0; ii < this._bases.length; ++ii) {
-            this._bases[ii].display.visible = ii < fullSeq.length && this._bases[ii].type !== EPars.RNABASE_CUT;
+        if (!this._showNucleotideRange) {
+            for (let ii = 0; ii < this._bases.length; ++ii) {
+                this._bases[ii].display.visible = this.isNucleotidePartOfSequence(ii);
+            }
         }
 
         let basesMoved = false;
@@ -2497,6 +2499,26 @@ export default class Pose2D extends ContainerObject implements Updatable {
             this._width / 2 - this._bases[baseIndex].x,
             this._height / 2 - this._bases[baseIndex].y
         );
+    }
+
+    public showNucleotideRange(range: [number, number] | null) {
+        const [start, end] = range ?? [1, this._bases.length];
+        if (start < 1 || end > this._bases.length || start >= end) {
+            // eslint-disable-next-line
+            console.warn(`Invalid nucleotide range [${start}, ${end}]`);
+            return;
+        }
+
+        this._showNucleotideRange = Boolean(range);
+        if (!range) {
+            return;
+        }
+
+        for (let i = 0; i < this._bases.length; ++i) {
+            this._bases[i].container.visible = i >= (start - 1)
+                && i < end
+                && this.isNucleotidePartOfSequence(i);
+        }
     }
 
     private computeLayout(fast: boolean = false): void {
@@ -3311,6 +3333,10 @@ export default class Pose2D extends ContainerObject implements Updatable {
         return base;
     }
 
+    private isNucleotidePartOfSequence(index: number) {
+        return index < this.fullSequence.length && this._bases[index].type !== EPars.RNABASE_CUT;
+    }
+
     private static createDefaultLocks(sequenceLength: number): boolean[] {
         let locks: boolean[] = new Array<boolean>(sequenceLength);
         for (let ii = 0; ii < sequenceLength; ++ii) {
@@ -3522,6 +3548,9 @@ export default class Pose2D extends ContainerObject implements Updatable {
     private _anchoredObjects: RNAAnchorObject[] = [];
     private _highlightEnergyText: boolean = false;
     private _energyHighlights: SceneObject[] = [];
+
+    private _showNucleotideRange = false;
+
     /*
      * NEW HIGHLIGHT.
      *  - Input: List of nucleotides that we wish to highlight.

--- a/src/eterna/ui/NucleotideRangeSelector.ts
+++ b/src/eterna/ui/NucleotideRangeSelector.ts
@@ -1,0 +1,99 @@
+import {Flashbang, KeyCode} from 'flashbang';
+import TextInputPanel from './TextInputPanel';
+import Dialog from './Dialog';
+import GameButton from './GameButton';
+
+interface NucleotideRangeSelectorProps {
+    initialRange: [number, number];
+    isPartialRange: boolean;
+}
+
+interface NucleotideRangeSelectorResult {
+    startIndex: number;
+    endIndex: number;
+    clearRange: boolean;
+}
+
+export default class NucleotideRangeSelector extends Dialog<NucleotideRangeSelectorResult> {
+    private static readonly config = {
+        title: 'Select nucleotide range to show',
+        startFieldName: 'Start Index',
+        endFieldName: 'End Index'
+    };
+
+    private static readonly theme = {
+        width: 140,
+        panelSpacing: 10
+    };
+
+    private _props: NucleotideRangeSelectorProps;
+
+    constructor(props: NucleotideRangeSelectorProps) {
+        super();
+        this._props = props;
+    }
+
+    protected added() {
+        super.added();
+        const {config, theme} = NucleotideRangeSelector;
+
+        const inputPanel = new TextInputPanel();
+        inputPanel.title = config.title;
+
+        const startField = inputPanel.addField(config.startFieldName, theme.width);
+        const endField = inputPanel.addField(config.endFieldName, theme.width);
+        const [start, end] = this._props.initialRange;
+        startField.text = `${start}`;
+        endField.text = `${end}`;
+
+        this.addObject(inputPanel, this.container);
+
+        let clearButton: GameButton | null = null;
+        if (this._props.isPartialRange) {
+            clearButton = new GameButton()
+                .label(
+                    'Clear range (View all nucleotides)',
+                    14
+                );
+            this.regs.add(clearButton.clicked.connect(() => {
+                this.close({
+                    clearRange: true,
+                    startIndex: -1,
+                    endIndex: -1
+                });
+            }));
+            this.addObject(clearButton, this.container);
+        }
+
+        startField.setFocus();
+        inputPanel.setHotkeys(KeyCode.Enter, null, KeyCode.Escape, null);
+
+        inputPanel.cancelClicked.connect(() => this.close(null));
+        inputPanel.okClicked.connect(() => {
+            const dict = inputPanel.getFieldValues();
+            const startIndex = parseInt(dict.get(config.startFieldName), 10);
+            const endIndex = parseInt(dict.get(config.endFieldName), 10);
+            if ([startIndex, endIndex].some(Number.isNaN)) {
+                this.close(null);
+            } else {
+                this.close({
+                    startIndex,
+                    endIndex,
+                    clearRange: false
+                });
+            }
+        });
+
+        const updateLocation = () => {
+            inputPanel.display.position.x = (Flashbang.stageWidth - inputPanel.width) * 0.5;
+            inputPanel.display.position.y = (Flashbang.stageHeight - inputPanel.height) * 0.5;
+
+            if (clearButton) {
+                clearButton.display.position.x = (Flashbang.stageWidth - clearButton.display.width) * 0.5;
+                clearButton.display.position.y = inputPanel.display.position.y + inputPanel.height + theme.panelSpacing;
+            }
+        };
+        updateLocation();
+        this.regs.add(this.mode.resized.connect(updateLocation));
+    }
+}

--- a/src/eterna/ui/NucleotideRangeSelector.ts
+++ b/src/eterna/ui/NucleotideRangeSelector.ts
@@ -31,19 +31,21 @@ class NucleotideRangeSelectorInput extends TextInputPanel {
     protected added() {
         super.added();
 
-        const {_okButton, _clearButton, _cancelButton} = this;
-
         const spacing = 30;
-        const buttonsWidth = _okButton.container.width
-            + spacing
-            + _clearButton.container.width
-            + spacing
-            + _cancelButton.container.width;
+        const buttons = [this._okButton, this._clearButton, this._cancelButton];
 
-        _okButton.display.position.x = (this._width - buttonsWidth) / 2;
-        _clearButton.display.position.x = _okButton.display.position.x + _okButton.container.width + spacing;
-        _clearButton.display.position.y = _okButton.display.position.y;
-        _cancelButton.display.position.x = _clearButton.display.position.x + _clearButton.container.width + spacing;
+        const totalWidth = buttons.reduce(
+            (prev, cur) => prev + cur.container.width + spacing,
+            -spacing
+        );
+        buttons.forEach((b, index) => {
+            b.display.position.x = (this._width - totalWidth) / 2;
+            for (let i = index - 1; i >= 0; --i) {
+                b.display.position.x += buttons[i].container.width + spacing;
+            }
+        });
+
+        this._clearButton.display.position.y = this._okButton.display.position.y;
     }
 }
 

--- a/src/eterna/ui/NucleotideRangeSelector.ts
+++ b/src/eterna/ui/NucleotideRangeSelector.ts
@@ -16,7 +16,7 @@ interface NucleotideRangeSelectorResult {
 
 export default class NucleotideRangeSelector extends Dialog<NucleotideRangeSelectorResult> {
     private static readonly config = {
-        title: 'Select nucleotide range to show',
+        title: 'Select Nucleotide Range to View',
         startFieldName: 'Start Index',
         endFieldName: 'End Index'
     };

--- a/src/eterna/ui/TextInputPanel.ts
+++ b/src/eterna/ui/TextInputPanel.ts
@@ -118,8 +118,8 @@ export default class TextInputPanel extends GamePanel {
         }
     }
 
-    private readonly _okButton: GameButton;
-    private readonly _cancelButton: GameButton;
+    protected readonly _okButton: GameButton;
+    protected readonly _cancelButton: GameButton;
     private readonly _fontSize: number = 14;
 
     private _fields: InputField[] = [];

--- a/src/eterna/ui/Toolbar.ts
+++ b/src/eterna/ui/Toolbar.ts
@@ -52,6 +52,7 @@ export default class Toolbar extends ContainerObject {
     public copyButton: GameButton;
     public pasteButton: GameButton;
     public nucleotideFindButton: GameButton;
+    public nucleotideRangeButton: GameButton;
 
     public freezeButton: GameButton;
 
@@ -295,6 +296,16 @@ export default class Toolbar extends ContainerObject {
             .hotkey(KeyCode.KeyJ);
 
         this.actionMenu.addSubMenuButton(0, this.nucleotideFindButton);
+
+        this.nucleotideRangeButton = new GameButton()
+            .allStates(Bitmaps.NovaPuzzleImg)
+            .disabled(null)
+            .label('View Nucleotide Range', 14)
+            .scaleBitmapToLabel()
+            .tooltip('Enter a nucleotide range to view (v)')
+            .hotkey(KeyCode.KeyV);
+
+        this.actionMenu.addSubMenuButton(0, this.nucleotideRangeButton);
 
         this.boostersMenu = new GameButton().allStates(Bitmaps.NovaBoosters).disabled(null);
         if (this._boostersData != null && this._boostersData.actions != null) {


### PR DESCRIPTION
resolves #299 

Puzzle IDs for testing:
* No pip mode: 9386699
* With pip mode: 9386716

* Accessible through the hamburger menu or 'V' hotkey.
* Takes the sequence length into account to initialize the dialog. 
* In PiP mode, it takes the minimum of the length across the sequences.
* It remembers the last entered range
* A 'Clear range' button is shown if a range was set, that clears and displays all nucleotides.

![image](https://user-images.githubusercontent.com/11358110/81339219-cb098f80-907b-11ea-85d3-9311c3448ec7.png)

