### PR TITLE
Dynamic arrows

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -474,14 +474,15 @@ export default class PoseEditMode extends GameMode {
     }
 
     private onHelpClicked() {
-        const toolBar = this.toolbar;
-        const getBounds = (elem: ContainerObject) => new Rectangle(
-            // worldTransform seems unreliable. TODO investigate.
-            elem.container.x + toolBar.container.x + toolBar.position.x,
-            elem.container.y + toolBar.container.y + toolBar.position.y,
-            elem.container.width,
-            elem.container.height
-        );
+        const getBounds = (elem: ContainerObject) => {
+            const globalPos = elem.container.toGlobal(new Point());
+            return new Rectangle(
+                globalPos.x,
+                globalPos.y,
+                elem.container.width,
+                elem.container.height
+            );
+        };
 
         const switchStateButton = Boolean(this.toolbar.stateToggle.container.parent)
             && this.toolbar.stateToggle.display.visible;

--- a/src/eterna/rscript/RNAScript.ts
+++ b/src/eterna/rscript/RNAScript.ts
@@ -12,6 +12,8 @@ import RScriptOp from './RScriptOp';
 import RScriptOpTree from './RScriptOpTree';
 import ROPPopPuzzle from './ROPPopPuzzle';
 import ROPShowMissionScreen from './ROPShowMissionScreen';
+import ROPUIArrow from './ROPUIArrow';
+import ROPUITooltip from './ROPUITooltip';
 
 export default class RNAScript {
     constructor(puz: Puzzle, ui: PoseEditMode) {
@@ -103,6 +105,8 @@ export default class RNAScript {
         let rnaRegex = /^RNA(SetBase|ChangeMode|EnableModification|SetPainter|ChangeState|SetZoom|SetPIP)$/ig;
         const popPuzzle = /PopPuzzle/;
         const showMissionScreen = /ShowMissionScreen/;
+        const uiArrow = /(Show|Hide)UIArrow/;
+        const uiTooltip = /(Show|Hide)UITooltip/;
 
         let regResult: RegExpExecArray | null;
         if ((regResult = preRegex.exec(op)) != null) {
@@ -167,6 +171,12 @@ export default class RNAScript {
             return new ROPPopPuzzle(this._env);
         } else if ((regResult = showMissionScreen.exec(op))) {
             return new ROPShowMissionScreen(this._env);
+        } else if ((regResult = uiArrow.exec(op))) {
+            const [match, show] = regResult;
+            return new ROPUIArrow(this._env, show.toUpperCase() === 'SHOW');
+        } else if ((regResult = uiTooltip.exec(op))) {
+            const [match, show] = regResult;
+            return new ROPUITooltip(this._env, show.toUpperCase() === 'SHOW');
         }
         // Shouldn't reach here ever.
         throw new Error(`Invalid operation: ${op}`);

--- a/src/eterna/rscript/ROPUIArrow.ts
+++ b/src/eterna/rscript/ROPUIArrow.ts
@@ -71,6 +71,9 @@ export default class ROPUIArrow extends RScriptOp {
     }
 
     private clear() {
-        (this._env.getVar(ROPUIArrow.id) as GameObject)?.destroySelf();
+        const elem = this._env.getVar(ROPUIArrow.id) as GameObject;
+        if (elem) {
+            elem.destroySelf();
+        }
     }
 }

--- a/src/eterna/rscript/ROPUIArrow.ts
+++ b/src/eterna/rscript/ROPUIArrow.ts
@@ -1,0 +1,76 @@
+import {GameObject} from 'flashbang';
+import RScriptEnv from './RScriptEnv';
+import RScriptOp from './RScriptOp';
+import RScriptArrow from './RScriptArrow';
+
+export default class ROPUIArrow extends RScriptOp {
+    private static readonly theme = {
+        thickness: 35,
+        length: 55,
+        colors: {
+            outline: 0x000000,
+            fill: 0xFFFF00
+        }
+    };
+
+    private static id = 'uiArrow';
+    private _uiElementId: string;
+    private _side: string;
+    private _show: boolean;
+
+    constructor(env: RScriptEnv, show: boolean) {
+        super(env);
+        this._show = show;
+    }
+
+    public exec(): void {
+        if (this._show) {
+            const {theme} = ROPUIArrow;
+            this.clear();
+            const getBounds = () => this._env.getUIElementBounds(this._uiElementId);
+            if (getBounds()) {
+                const arrow = new RScriptArrow(
+                    theme.thickness,
+                    theme.length,
+                    theme.colors.outline,
+                    theme.colors.fill
+                );
+
+                const updatePosition = () => {
+                    const bounds = getBounds();
+                    arrow.display.position.x = bounds.x + bounds.width / 2;
+                    if (this._side === 'bottom') {
+                        arrow.display.position.y = bounds.y + bounds.height;
+                        arrow.rotation = 90;
+                    } else {
+                        arrow.display.position.y = bounds.y;
+                        arrow.rotation = -90;
+                    }
+                };
+
+                updatePosition();
+                this._env.addObject(arrow, this._env.container);
+                this._env.setVar(ROPUIArrow.id, arrow);
+                arrow.regs.add(this._env.mode.resized.connect(updatePosition));
+            }
+        } else {
+            this.clear();
+        }
+    }
+
+    /* override */
+    protected parseArgument(arg: string, i: number) {
+        // ShowUIArrow uiElementId, [top|bottom]
+        if (i === 0) {
+            // uiElementId
+            this._uiElementId = arg.toUpperCase();
+        } else if (i === 1) {
+            // top|bottom
+            this._side = arg;
+        }
+    }
+
+    private clear() {
+        (this._env.getVar(ROPUIArrow.id) as GameObject)?.destroySelf();
+    }
+}

--- a/src/eterna/rscript/ROPUITooltip.ts
+++ b/src/eterna/rscript/ROPUITooltip.ts
@@ -17,30 +17,25 @@ export default class ROPUITooltip extends RScriptOp {
     }
 
     public exec(): void {
-        try {
-            if (this._show) {
-                this.clear();
-                const getBounds = () => this._env.getUIElementBounds(this._uiElementId);
-                if (getBounds()) {
-                    const tooltip = new HelpToolTip({
-                        text: this._text,
-                        tailLength: this._tailLength,
-                        side: this._side as HelpToolTipSide,
-                        positioner: [getBounds, 0]
-                    });
-                    const updatePosition = () => tooltip.updatePosition();
+        if (this._show) {
+            this.clear();
+            const getBounds = () => this._env.getUIElementBounds(this._uiElementId);
+            if (getBounds()) {
+                const tooltip = new HelpToolTip({
+                    text: this._text,
+                    tailLength: this._tailLength,
+                    side: this._side as HelpToolTipSide,
+                    positioner: [getBounds, 0]
+                });
+                const updatePosition = () => tooltip.updatePosition();
 
-                    updatePosition();
-                    this._env.addObject(tooltip, this._env.container);
-                    this._env.setVar(ROPUITooltip.id, tooltip);
-                    tooltip.regs.add(this._env.mode.resized.connect(updatePosition));
-                }
-            } else {
-                this.clear();
+                updatePosition();
+                this._env.addObject(tooltip, this._env.container);
+                this._env.setVar(ROPUITooltip.id, tooltip);
+                tooltip.regs.add(this._env.mode.resized.connect(updatePosition));
             }
-        } catch (e) {
-            // eslint-disable-next-line
-            console.error(e);
+        } else {
+            this.clear();
         }
     }
 
@@ -63,6 +58,9 @@ export default class ROPUITooltip extends RScriptOp {
     }
 
     private clear() {
-        (this._env.getVar(ROPUITooltip.id) as GameObject)?.destroySelf();
+        const elem = (this._env.getVar(ROPUITooltip.id) as GameObject);
+        if (elem) {
+            elem.destroySelf();
+        }
     }
 }

--- a/src/eterna/rscript/ROPUITooltip.ts
+++ b/src/eterna/rscript/ROPUITooltip.ts
@@ -1,0 +1,68 @@
+import HelpToolTip, {HelpToolTipSide} from 'eterna/ui/help/HelpToolTip';
+import {GameObject} from 'flashbang';
+import RScriptEnv from './RScriptEnv';
+import RScriptOp from './RScriptOp';
+
+export default class ROPUITooltip extends RScriptOp {
+    private static id = 'uiTooltip';
+    private _uiElementId: string;
+    private _text: string;
+    private _tailLength: number;
+    private _side: string;
+    private _show: boolean;
+
+    constructor(env: RScriptEnv, show: boolean) {
+        super(env);
+        this._show = show;
+    }
+
+    public exec(): void {
+        try {
+            if (this._show) {
+                this.clear();
+                const getBounds = () => this._env.getUIElementBounds(this._uiElementId);
+                if (getBounds()) {
+                    const tooltip = new HelpToolTip({
+                        text: this._text,
+                        tailLength: this._tailLength,
+                        side: this._side as HelpToolTipSide,
+                        positioner: [getBounds, 0]
+                    });
+                    const updatePosition = () => tooltip.updatePosition();
+
+                    updatePosition();
+                    this._env.addObject(tooltip, this._env.container);
+                    this._env.setVar(ROPUITooltip.id, tooltip);
+                    tooltip.regs.add(this._env.mode.resized.connect(updatePosition));
+                }
+            } else {
+                this.clear();
+            }
+        } catch (e) {
+            // eslint-disable-next-line
+            console.error(e);
+        }
+    }
+
+    /* override */
+    protected parseArgument(arg: string, i: number) {
+        // ShowUIArrow uiElementId, [text], [top|bottom], [tailLength];
+        if (i === 0) {
+            // uiElementId
+            this._uiElementId = arg.toUpperCase();
+        } else if (i === 1) {
+            // text
+            this._text = this._env.getVar(arg) as string;
+        } else if (i === 2) {
+            // top|bottom
+            this._side = arg;
+        } else if (i === 3) {
+            // tailLength
+            this._tailLength = parseInt(arg, 10);
+        }
+    }
+
+    private clear() {
+        (this._env.getVar(ROPUITooltip.id) as GameObject)?.destroySelf();
+    }
+}

--- a/src/eterna/rscript/RScriptEnv.ts
+++ b/src/eterna/rscript/RScriptEnv.ts
@@ -1,5 +1,7 @@
 import * as log from 'loglevel';
-import {Container, DisplayObject} from 'pixi.js';
+import {
+    Container, DisplayObject, Rectangle, Point
+} from 'pixi.js';
 import {ContainerObject, Enableable, GameObject} from 'flashbang';
 import EPars from 'eterna/EPars';
 import PoseEditMode from 'eterna/mode/PoseEdit/PoseEditMode';
@@ -122,6 +124,36 @@ export default class RScriptEnv extends ContainerObject {
             uiElement = this.getUIElement(elementID);
         }
         return [uiElement, elementID, altParam];
+    }
+
+    public getUIElementBounds(key: string): Rectangle | null {
+        try {
+            const [uiElement] = this.getUIElementFromID(key);
+            if (uiElement instanceof Rectangle) {
+                // This is a rectangle whithin the palette
+                const [palette] = this.getUIElementFromID(RScriptUIElementID.PALETTE);
+                const obj = palette as GameObject;
+                const rect = uiElement as Rectangle;
+                const globalPos = obj.display.toGlobal(new Point());
+                return new Rectangle(
+                    globalPos.x + rect.x,
+                    globalPos.y + rect.y,
+                    rect.width,
+                    rect.height
+                );
+            } else {
+                const obj = uiElement as GameObject;
+                const globalPos = obj.display.toGlobal(new Point());
+                return new Rectangle(
+                    globalPos.x,
+                    globalPos.y,
+                    obj.display.getLocalBounds().width,
+                    obj.display.getLocalBounds().height
+                );
+            }
+        } catch (e) {
+            return null;
+        }
     }
 
     public get totalConstraints(): number | null {

--- a/src/eterna/ui/help/HelpToolTip.ts
+++ b/src/eterna/ui/help/HelpToolTip.ts
@@ -4,7 +4,7 @@ import Fonts from 'eterna/util/Fonts';
 
 export type ToolTipPositioner = [() => Rectangle, number];
 
-type HelpToolTipSide = 'top' | 'bottom';
+export type HelpToolTipSide = 'top' | 'bottom';
 
 interface HelpToolTipProps {
     text: string;


### PR DESCRIPTION
2 new instructions `ShowUIArrow` and `ShowUITooltip`
Their corresponding elements stick to their target even if the screen is resized. 

To replace  `ShowArrowLocation`:
* (Show|Hide)UIArrow elementId [top|bottom]
* Example: `ShowUIArrow G;`

To replace combinations of `ShowArrowLocation` and `ShowTextboxLocation`:
* (Show|Hide)UITooltip elementId, text, [top|bottom], [tailLength]
* Example: `ShowUITooltip toggletarget, "Target mode shows the desired shape", top, 45;`

![image](https://user-images.githubusercontent.com/11358110/84246067-0a405b80-aad4-11ea-87a1-23060f7daafd.png)

![image](https://user-images.githubusercontent.com/11358110/84246077-0d3b4c00-aad4-11ea-899e-33463032177f.png)

