### PR TITLE
Implemented ANY_PAIR in the undo block

### DIFF
--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -217,6 +217,7 @@ export default class UndoBlock {
         this.setParam(UndoBlockParam.GU, EPars.numGUPairs(seq, bestPairs), temp, pseudoknots);
         this.setParam(UndoBlockParam.GC, EPars.numGCPairs(seq, bestPairs), temp, pseudoknots);
         this.setParam(UndoBlockParam.AU, EPars.numUAPairs(seq, bestPairs), temp, pseudoknots);
+        this.setParam(UndoBlockParam.ANY_PAIR, EPars.numPairs(bestPairs), temp, pseudoknots);
         this.setParam(UndoBlockParam.STACK, EPars.getLongestStackLength(bestPairs), temp, pseudoknots);
         this.setParam(UndoBlockParam.REPETITION, EPars.getSequenceRepetition(
             EPars.sequenceToString(seq), 5


### PR DESCRIPTION
TESTS CURRENTLY FAIL - I had to run to sleep, and I couldn't figure out why the test failed. IDK If it fails on dev or not, I will check tomorrow if no one merges by then.
In case it's just on my machine due to a global library, here are the errors:

```(node:27024) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added. Use emitter.setMaxListeners() to increase limit
(node:27024) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unhandledRejection listeners added. Use emitter.setMaxListeners() to increase limit
FAIL src/eterna/folding/__tests__/Folder.test.ts (11.013s)
× linearfoldC:MFETests (114ms)````

```● linearfoldC:MFETests

  expect(received).resolves.toBeUndefined()

  Received promise rejected instead of resolved
  Rejected to value: [Error: expect(received).toEqual(expected) // deep equality·
  - Expected  - 1
  + Received  + 1·
  @@ -18,11 +18,11 @@
      34,
      -209,
      33,
      -103,
      6,
  -   -627,
  +   627,
      5,
      -103,
      4,
      -203,
      3,]

    27 |
    28 | test('linearfoldC:MFETests', () => {
  > 29 |     return expect(CreateFolder(LinearFoldC).then((folder) => {
       |            ^
    30 |         let expectedFE: number[] = [
    31 |             -430,// -4.29,
    32 |             -248,

    at expect (../node_modules/expect/build/index.js:134:15)
    at Object.<anonymous>.test (eterna/folding/__tests__/Folder.test.ts:29:12)```
