### PR TITLE
Fix base marking in PiP mode

### DIFF
--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -501,9 +501,10 @@ export default class Pose2D extends ContainerObject implements Updatable {
     public onPoseMouseDownPropagate(e: InteractionEvent, closestIndex: number): void {
         let altDown: boolean = Flashbang.app.isAltKeyDown;
         let ctrlDown: boolean = Flashbang.app.isControlKeyDown || Flashbang.app.isMetaKeyDown;
+        const ctrlDownOrBaseMarking = ctrlDown || this.currentColor === EPars.RNABASE_BASE_MARK;
 
-        if ((this._coloring && !altDown) || ctrlDown) {
-            if (ctrlDown && closestIndex >= this.sequence.length) {
+        if ((this._coloring && !altDown) || ctrlDownOrBaseMarking) {
+            if (ctrlDownOrBaseMarking && closestIndex >= this.sequence.length) {
                 return;
             }
             this.onPoseMouseDown(e, closestIndex);


### PR DESCRIPTION
Make sure bases are marked in all poses when using the base marking button in PiP - (same behavior as ctrl+click).