### PR TITLE
All constraints must be satisfied for submission

### DIFF
--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -474,7 +474,7 @@ export default class PuzzleEditMode extends GameMode {
         if (!this._constraintBar.updateConstraints({
             undoBlocks: this._seqStack[this._stackLevel],
             targetConditions: this._targetConditions
-        })) {
+        }) && !Eterna.DEV_MODE) {
             this.showNotification('You should first solve your puzzle before submitting it!');
             return;
         }
@@ -495,16 +495,6 @@ export default class PuzzleEditMode extends GameMode {
 
             if (secstruct.length !== firstSecstruct.length) {
                 this.showNotification("Structure lengths don't match");
-                return;
-            }
-
-            if (
-                !EPars.arePairsSame(
-                    this.getCurrentTargetPairs(ii),
-                    this.getCurrentUndoBlock(ii).getPairs(EPars.DEFAULT_TEMPERATURE)
-                ) && !Eterna.DEV_MODE
-            ) {
-                this.showNotification('You should first solve your puzzle before submitting it!');
                 return;
             }
 

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -471,6 +471,14 @@ export default class PuzzleEditMode extends GameMode {
     private onSubmitPuzzle(): void {
         let firstSecstruct: string = this._structureInputs[0].structureString;
 
+        if (!this._constraintBar.updateConstraints({
+            undoBlocks: this._seqStack[this._stackLevel],
+            targetConditions: this._targetConditions
+        })) {
+            this.showNotification('You should first solve your puzzle before submitting it!');
+            return;
+        }
+
         for (let ii = 0; ii < this._poses.length; ii++) {
             let secstruct: string = this._structureInputs[ii].structureString;
 


### PR DESCRIPTION
Resolves #127 

This checks that all constraints are satisfied prior to submission; there is an existing check for just the sequence. Presumably, this would cover player-made constraints, since the only other constraints (available in the puzzlemaker), pair count constraints, are also checked.