### PR TITLE
Single-state constraints don't show a state number

### DIFF
--- a/src/eterna/constraints/ConstraintBar.ts
+++ b/src/eterna/constraints/ConstraintBar.ts
@@ -64,11 +64,11 @@ export default class ConstraintBar extends ContainerObject {
     private _drag = false;
     private _previousDragPos = -1;
 
-    constructor(constraints: Constraint<BaseConstraintStatus>[] | null) {
+    constructor(constraints: Constraint<BaseConstraintStatus>[] | null, states = 1) {
         super();
         this._constraints = constraints
             ? constraints.map(
-                (constraint) => ({constraint, constraintBox: new ConstraintBox(false), highlightCache: null})
+                (constraint) => ({constraint, constraintBox: new ConstraintBox(false, states), highlightCache: null})
             ) : [];
 
         Eterna.settings.highlightRestricted.connect(() => {

--- a/src/eterna/constraints/ConstraintBox.ts
+++ b/src/eterna/constraints/ConstraintBox.ts
@@ -45,9 +45,10 @@ export interface ConstraintBoxConfig {
 }
 
 export default class ConstraintBox extends ContainerObject implements Enableable {
-    constructor(forMissionScreen: boolean) {
+    constructor(forMissionScreen: boolean, states = 1) {
         super();
         this._forMissionScreen = forMissionScreen;
+        this._states = states;
 
         this._bgGraphics = new Graphics();
         this._bgGraphics.interactiveChildren = false;
@@ -233,7 +234,7 @@ export default class ConstraintBox extends ContainerObject implements Enableable
             this._sideText.position = new Point(-deltaWidth / 2, this._opaqueBackdrop.height + 10);
         }
 
-        if (config.stateNumber && !this._forMissionScreen) {
+        if (config.stateNumber && !this._forMissionScreen && this._states > 1) {
             this._stateText.visible = true;
             this._stateText.text = config.stateNumber.toString();
         }
@@ -479,6 +480,8 @@ export default class ConstraintBox extends ContainerObject implements Enableable
     private _forMissionScreen: boolean;
 
     private _satisfied: boolean;
+
+    private readonly _states: number;
 
     private _bgGraphics: Graphics;
     private _backlight: Graphics;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -782,7 +782,7 @@ export default class PoseEditMode extends GameMode {
             this._toolbar.palette.clickTarget(PaletteTargetType.A);
         }
 
-        this._constraintBar = new ConstraintBar(this._puzzle.constraints);
+        this._constraintBar = new ConstraintBar(this._puzzle.constraints, this._puzzle.getSecstructs.length);
         this._constraintBar.display.visible = false;
         this.addObject(this._constraintBar, this._constraintsLayer);
         this._constraintBar.sequenceHighlights.connect((highlightInfos: HighlightInfo[] | null) => {
@@ -2226,7 +2226,7 @@ export default class PoseEditMode extends GameMode {
                 (constraint) => !(constraint instanceof ShapeConstraint || constraint instanceof AntiShapeConstraint)
             ).map(
                 (constraint) => {
-                    let box = new ConstraintBox(true);
+                    let box = new ConstraintBox(true, this._puzzle.getSecstructs().length);
                     box.setContent(constraint.getConstraintBoxConfig(
                         constraint.evaluate({
                             undoBlocks: this._seqStacks[this._stackLevel],

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -266,7 +266,7 @@ export default class PuzzleEditMode extends GameMode {
 
         this._constraintBar = new ConstraintBar(Utility.range(this._numTargets).map(
             (stateIndex) => new ShapeConstraint(stateIndex)
-        ));
+        ), this._numTargets);
         this.addObject(this._constraintBar, this.container);
         this._constraintBar.layout();
 


### PR DESCRIPTION
Resolves #240 

This prevents constraints from displaying a state number if the puzzle is single-state