### PR TITLE
Toolbar is handled correctly on small screens

### DIFF
--- a/src/eterna/constraints/ConstraintBar.ts
+++ b/src/eterna/constraints/ConstraintBar.ts
@@ -1,5 +1,5 @@
 import {
-    ContainerObject, Flashbang, ParallelTask, LocationTask, Easing, AlphaTask, SceneObject
+    ContainerObject, Flashbang, ParallelTask, LocationTask, Easing, AlphaTask
 } from 'flashbang';
 import {
     Point, Graphics, Container, Sprite
@@ -12,6 +12,7 @@ import {RScriptUIElementID} from 'eterna/rscript/RScriptUIElement';
 import BitmapManager from 'eterna/resources/BitmapManager';
 import Bitmaps from 'eterna/resources/Bitmaps';
 import Assert from 'flashbang/util/Assert';
+import GraphicsObject from 'flashbang/objects/GraphicsObject';
 import ShapeConstraint, {AntiShapeConstraint} from './constraints/ShapeConstraint';
 import ConstraintBox from './ConstraintBox';
 import Constraint, {BaseConstraintStatus, HighlightInfo, ConstraintContext} from './Constraint';
@@ -48,7 +49,7 @@ export default class ConstraintBar extends ContainerObject {
     public sequenceHighlights: Value<HighlightInfo[]> | Value<null> = new Value(null);
 
     private _collapsed = false;
-    private _background: SceneObject<Graphics>;
+    private _background: GraphicsObject;
     private _mask: Graphics;
     private _constraintsRoot: Container;
     private _constraintsLayer: Container;
@@ -83,7 +84,7 @@ export default class ConstraintBar extends ContainerObject {
         if (drawerEnabled) {
             // Background
             this._background = (() => {
-                const bg = new SceneObject(new Graphics());
+                const bg = new GraphicsObject();
                 this.addObject(bg, this.container);
 
                 bg.pointerDown.connect((e: InteractionEvent) => {

--- a/src/eterna/mode/DesignBrowser/ViewSolutionOverlay.ts
+++ b/src/eterna/mode/DesignBrowser/ViewSolutionOverlay.ts
@@ -34,6 +34,7 @@ import Feedback from 'eterna/Feedback';
 import SliderBar from 'eterna/ui/SliderBar';
 import {FontWeight} from 'flashbang/util/TextBuilder';
 import HTMLTextObject from 'eterna/ui/HTMLTextObject';
+import GraphicsObject from 'flashbang/objects/GraphicsObject';
 import CopyTextDialogMode from '../CopyTextDialogMode';
 import ThumbnailAndTextButton from './ThumbnailAndTextButton';
 import GameMode from '../GameMode';
@@ -105,7 +106,7 @@ export default class ViewSolutionOverlay extends ContainerObject {
         const {theme} = ViewSolutionOverlay;
 
         // Background
-        this._panelBG = new SceneObject(new Graphics());
+        this._panelBG = new GraphicsObject();
         this._panelBG.pointerMove.connect((e) => {
             if (e.data.getLocalPosition(this._panelBG.display).x > 0) {
                 e.stopPropagation();
@@ -182,7 +183,7 @@ export default class ViewSolutionOverlay extends ContainerObject {
             this._content.destroySelf();
         }
 
-        this._content = new SceneObject(new Container());
+        this._content = new ContainerObject();
         this.addObject(this._content, this.container);
 
         // Header
@@ -669,8 +670,8 @@ export default class ViewSolutionOverlay extends ContainerObject {
 
     private readonly _props: ViewSolutionOverlayProps;
 
-    private _content: SceneObject<Container>;
-    private _panelBG: SceneObject<Graphics>;
+    private _content: ContainerObject;
+    private _panelBG: GraphicsObject;
 
     private _inputContainer: VLayoutContainer;
     private _commentsTitle: Text;

--- a/src/eterna/ui/EternaMenu.ts
+++ b/src/eterna/ui/EternaMenu.ts
@@ -3,6 +3,7 @@ import {Enableable, PointerCapture, DisplayUtil} from 'flashbang';
 import {UnitSignal} from 'signals';
 import GameButton from './GameButton';
 import GamePanel, {GamePanelType} from './GamePanel';
+import TrueWidthDisplay from './TrueWidthDisplay';
 
 export enum EternaMenuStyle {
     DEFAULT = 0, PULLUP
@@ -19,7 +20,9 @@ export default class EternaMenu extends GamePanel implements Enableable {
         super.added();
         this._background.visible = false;
         this.needsLayout();
-        if (this.inToolbar) this.display.name = 'EternaMenu';
+        if (this.inToolbar) {
+            this.display.name = 'EternaMenu';
+        }
     }
 
     public addItem(label: string, url: string): void {
@@ -249,9 +252,9 @@ export default class EternaMenu extends GamePanel implements Enableable {
         this._rightMargin = Math.max(lastButtonWidth, this._menus[lastIdx].panel.width) - lastButtonWidth;
 
         this.setSize(widthOffset, this._menuHeight + 1);
-        // A very hacky setup to signal to any HLayoutContainers that the width
-        // should be set to the width of the button (not the panel)
-        if (this.inToolbar) this.display.name = `EternaMenu${this.menuButtonWidth}`;
+        if (this.inToolbar) {
+            (this.display as TrueWidthDisplay).trueWidth = this.menuButtonWidth;
+        }
     }
 
     private readonly _style: EternaMenuStyle;

--- a/src/eterna/ui/EternaMenu.ts
+++ b/src/eterna/ui/EternaMenu.ts
@@ -127,6 +127,12 @@ export default class EternaMenu extends GamePanel implements Enableable {
         }
     }
 
+    public hideMenu() {
+        this._menus.forEach((menu) => {
+            menu.panel.display.visible = false;
+        });
+    }
+
     private createMenu(menuButton: GameButton): Menu {
         let menu: Menu = new Menu();
         menu.menuButton = menuButton;

--- a/src/eterna/ui/Toolbar.ts
+++ b/src/eterna/ui/Toolbar.ts
@@ -273,11 +273,9 @@ export default class Toolbar extends ContainerObject {
         this.actionMenu = new EternaMenu(EternaMenuStyle.PULLUP, true);
         this.addObject(this.actionMenu, this.lowerToolbarLayout);
 
-        this.actionMenu.toolbarUpdateLayout.connect(() => {
-            // If only called once, the arrows fly up. Calling it twice fixes that issue
+        this.regs.add(this.actionMenu.toolbarUpdateLayout.connect(() => {
             this.updateLayout();
-            this.updateLayout();
-        });
+        }));
 
         this.actionMenu.addMenuButton(new GameButton().allStates(Bitmaps.NovaMenu).disabled(undefined));
 
@@ -379,7 +377,7 @@ export default class Toolbar extends ContainerObject {
                 let data = this._boostersData.actions[ii];
                 Booster.create(this.mode as PoseEditMode, data).then((booster) => {
                     let button: GameButton = booster.createButton(14);
-                    button.clicked.connect(() => booster.onRun());
+                    this.regs.add(button.clicked.connect(() => booster.onRun()));
                     this.actionMenu.addSubMenuButtonAt(boosterMenuIdx, button, ii);
                     this.dynActionTools.push(button);
                 });
@@ -523,10 +521,10 @@ export default class Toolbar extends ContainerObject {
                     Booster.create(mode, data).then((booster) => {
                         booster.onLoad();
                         let button: GameButton = booster.createButton();
-                        button.clicked.connect(() => {
+                        this.regs.add(button.clicked.connect(() => {
                             mode.setPosesColor(booster.toolColor);
                             this._deselectAllPaintTools();
-                        });
+                        }));
                         this.dynPaintTools.push(button);
                         this.addObject(button, boosterPaintToolsLayout);
                         this.updateLayout();
@@ -633,24 +631,24 @@ export default class Toolbar extends ContainerObject {
             this.scrollContainer.setScroll(this.scrollContainer.scrollX - 10, this.scrollContainer.scrollY);
             this.updateArrowVisibility();
         };
-        this.rightArrow.pointerDown.connect(() => {
+        this.regs.add(this.rightArrow.pointerDown.connect(() => {
             endScroll();
             interval = setInterval(scrollRight, 100);
-        });
-        this.rightArrow.pointerUp.connect(() => endScroll());
-        this.leftArrow.pointerDown.connect(() => {
+        }));
+        this.regs.add(this.rightArrow.pointerUp.connect(() => endScroll()));
+        this.regs.add(this.leftArrow.pointerDown.connect(() => {
             endScroll();
             interval = setInterval(scrollLeft, 100);
-        });
-        this.leftArrow.pointerUp.connect(() => endScroll());
-        this.rightArrow.clicked.connect(() => {
+        }));
+        this.regs.add(this.leftArrow.pointerUp.connect(() => endScroll()));
+        this.regs.add(this.rightArrow.pointerTap.connect(() => {
             endScroll();
             scrollRight();
-        });
-        this.leftArrow.clicked.connect(() => {
+        }));
+        this.regs.add(this.leftArrow.pointerTap.connect(() => {
             endScroll();
             scrollLeft();
-        });
+        }));
 
         this.onResized();
 
@@ -694,22 +692,24 @@ export default class Toolbar extends ContainerObject {
         let mouseDown = false;
         let startingX: number;
         let startingScroll: number;
-        this.pointerDown.connect((e) => {
+        this.regs.add(this.pointerDown.connect((e) => {
             let {x, y} = e.data.global;
             if (this.lowerToolbarLayout.getBounds().contains(x, y)) {
                 mouseDown = true;
                 startingX = x;
                 startingScroll = this.scrollContainer.scrollX;
             }
-        });
-        this.pointerUp.connect((e) => {
-            mouseDown = false;
-        });
+        }));
 
-        this.scrollContainer.display.on('pointerupoutside', () => {
+        this.regs.add(this.pointerUp.connect((e) => {
             mouseDown = false;
-        });
-        this.pointerMove.connect((e) => {
+        }));
+
+        this.regs.add(this.scrollContainer.pointerUpOutside.connect(() => {
+            mouseDown = false;
+        }));
+
+        this.regs.add(this.pointerMove.connect((e) => {
             let {x, y} = e.data.global;
             if (e.data.buttons === 1 && mouseDown && this.lowerToolbarLayout.getBounds().contains(x, y)) {
                 let offset = x - startingX;
@@ -717,7 +717,7 @@ export default class Toolbar extends ContainerObject {
                     this.scrollContainer.scrollX = startingScroll - offset;
                 }
             }
-        });
+        }));
     }
 
     private updateLayout(): void {

--- a/src/eterna/ui/Toolbar.ts
+++ b/src/eterna/ui/Toolbar.ts
@@ -148,8 +148,6 @@ export default class Toolbar extends ContainerObject {
             this.rightArrow.display.visible = false;
             this.leftArrow.display.visible = false;
         }
-        // Hiding the menu ensures that it doesn't push the rest of the toolbar to the side
-        this.actionMenu.hideMenu();
         this.updateLayout();
     }
 
@@ -283,11 +281,17 @@ export default class Toolbar extends ContainerObject {
             .tooltip('Scroll left')
             .scaleBitmapToLabel();
 
-        this.actionMenu = new EternaMenu(EternaMenuStyle.PULLUP);
-        // The action menu needs to be outside of the inner HLayoutContainer to display the menu
-        this.addObject(this.actionMenu, this.scrollContainerContainer);
         this.addObject(this.leftArrow, this.scrollContainerContainer);
         this.addObject(this.scrollContainer, this.scrollContainerContainer);
+
+        this.actionMenu = new EternaMenu(EternaMenuStyle.PULLUP, true);
+        this.addObject(this.actionMenu, this.lowerToolbarLayout);
+
+        this.actionMenu.toolbarUpdateLayout.connect(() => {
+            // If only called once, the arrows fly up. Calling it twice fixes that issue
+            this.updateLayout();
+            this.updateLayout();
+        });
 
         this.actionMenu.addMenuButton(new GameButton().allStates(Bitmaps.NovaMenu).disabled(undefined));
 

--- a/src/eterna/ui/Toolbar.ts
+++ b/src/eterna/ui/Toolbar.ts
@@ -670,6 +670,37 @@ export default class Toolbar extends ContainerObject {
         this.regs.add(Eterna.settings.autohideToolbar.connectNotify((value) => {
             this.setToolbarAutohide(value);
         }));
+        this._setupToolbarDrag();
+    }
+
+    private _setupToolbarDrag() {
+        let mouseDown = false;
+        let startingX: number;
+        let startingScroll: number;
+        this.pointerDown.connect((e) => {
+            let {x, y} = e.data.global;
+            if (this.lowerToolbarLayout.getBounds().contains(x, y)) {
+                mouseDown = true;
+                startingX = x;
+                startingScroll = this.scrollContainer.scrollX;
+            }
+        });
+        this.pointerUp.connect((e) => {
+            mouseDown = false;
+        });
+
+        this.scrollContainer.display.on('pointerupoutside', () => {
+            mouseDown = false;
+        });
+        this.pointerMove.connect((e) => {
+            let {x, y} = e.data.global;
+            if (e.data.buttons === 1 && mouseDown && this.lowerToolbarLayout.getBounds().contains(x, y)) {
+                let offset = x - startingX;
+                if (Math.abs(offset) > 15) {
+                    this.scrollContainer.scrollX = startingScroll - offset;
+                }
+            }
+        });
     }
 
     private updateLayout(): void {

--- a/src/eterna/ui/Toolbar.ts
+++ b/src/eterna/ui/Toolbar.ts
@@ -57,6 +57,9 @@ export default class Toolbar extends ContainerObject {
 
     public actionMenu: EternaMenu;
 
+    public leftArrow: GameButton;
+    public rightArrow: GameButton;
+
     // Pose Editing
     public palette: NucleotidePalette;
     public pairSwapButton: GameButton;

--- a/src/eterna/ui/TrueWidthDisplay.ts
+++ b/src/eterna/ui/TrueWidthDisplay.ts
@@ -1,0 +1,5 @@
+import {Container} from 'pixi.js';
+
+export default class TrueWidthDisplay extends Container {
+    public trueWidth: number;
+}

--- a/src/eterna/vfx/LightRay.ts
+++ b/src/eterna/vfx/LightRay.ts
@@ -1,14 +1,10 @@
-import {Graphics} from 'pixi.js';
 import EPars from 'eterna/EPars';
 import {
-    SceneObject, SerialTask, AlphaTask, VisibleTask, Vector2
+    SerialTask, AlphaTask, VisibleTask, Vector2
 } from 'flashbang';
+import GraphicsObject from 'flashbang/objects/GraphicsObject';
 
-export default class LightRay extends SceneObject<Graphics> {
-    constructor() {
-        super(new Graphics());
-    }
-
+export default class LightRay extends GraphicsObject {
     public fadeIn(): void {
         this.display.alpha = 0;
         this.replaceNamedObject(LightRay.ANIM, new AlphaTask(1, 0.5));

--- a/src/flashbang/input/DisplayObjectPointerTarget.ts
+++ b/src/flashbang/input/DisplayObjectPointerTarget.ts
@@ -48,6 +48,20 @@ export default class DisplayObjectPointerTarget implements PointerTarget {
         return this._pointerUp;
     }
 
+    public get pointerUpOutside(): SignalView<InteractionEvent> {
+        if (this._pointerUpOutside == null) {
+            this._pointerUpOutside = new EventSignal(this.target, 'pointerupoutside');
+        }
+        return this._pointerUpOutside;
+    }
+
+    public get pointerCancel(): SignalView<InteractionEvent> {
+        if (this._pointerCancel == null) {
+            this._pointerCancel = new EventSignal(this.target, 'pointerupcancel');
+        }
+        return this._pointerCancel;
+    }
+
     public get pointerTap(): SignalView<InteractionEvent> {
         if (this._pointerTap == null) {
             this._pointerTap = new EventSignal(this.target, 'pointertap');
@@ -61,5 +75,7 @@ export default class DisplayObjectPointerTarget implements PointerTarget {
     private _pointerDown: EventSignal;
     private _pointerMoved: EventSignal;
     private _pointerUp: EventSignal;
+    private _pointerUpOutside: EventSignal;
+    private _pointerCancel: EventSignal;
     private _pointerTap: EventSignal;
 }

--- a/src/flashbang/input/PointerCapture.ts
+++ b/src/flashbang/input/PointerCapture.ts
@@ -1,84 +1,136 @@
-import {DisplayObject, Container} from 'pixi.js';
-import Flashbang from 'flashbang/core/Flashbang';
-import {Assert} from 'flashbang';
+import {Container, DisplayObject} from 'pixi.js';
+import {Assert, Flashbang, GameObject} from 'flashbang';
+import GraphicsObject from 'flashbang/objects/GraphicsObject';
 
-type InteractionPointerEvents = PIXI.interaction.InteractionPointerEvents;
 type InteractionEvent = PIXI.interaction.InteractionEvent;
 
-export default class PointerCapture {
-    constructor(root: Container) {
+/**
+ * Begins capturing pointer input. All pointer events not related to the passed Container will be
+ * routed to the given callback function before they reach their intended target. The callback
+ * can call {@link PIXI.interaction.InteractionEvent.stopPropagation} to prevent the event from
+ * being processed further.
+ *
+ * Capture begins when this object is added as the child of another GameObject via GameObject#addObject,
+ * and ends when it is removed via GameObject#removeObject
+ *
+ * Be aware that with the current implementation, we do intercept non-pointer events, but they
+ * will never be propogated (though you should most likely be using pointer events anyways to
+ * make sure it works on touchscreens, mice, etc!). However, non-pointer events will still be fired
+ * on the original objects if stopPropogation is not called.
+ *
+ * Note that all events captured are actually events registered on a surface added to the very top
+ * of the current mode - they do NOT represent an event fired on an arbitrary Container outside
+ * the bounds of the passed Container. This is the only way we can intercept events from PIXI.
+ */
+export default class PointerCapture extends GameObject {
+    constructor(root: Container, onEvent: (e: InteractionEvent) => void) {
+        super();
         this._root = root;
-    }
-
-    /**
-     * Begins capturing pointer input. All pointer events not related to that DisplayObject will be
-     * routed to the given callback function before they reach their intended target. The callback
-     * can call {@link PIXI.interaction.InteractionEvent.stopPropagation} to prevent the event from
-     * being processed further.
-     */
-    public beginCapture(onEvent: (e: InteractionEvent) => void): void {
-        if (this.hasCapture) {
-            return;
-        }
-
-        this._rootWasInteractive = this._root.interactive;
-        this._root.interactive = true;
-
         this._onEvent = onEvent;
+        this._surface = new GraphicsObject();
+        this._surface.display.alpha = 0;
+    }
 
-        PointerCapture._captures.push(this);
+    added() {
+        Assert.assertIsDefined(this.mode?.container);
+        this.regs.add(this.mode.resized.connect(() => this.onModeResized()));
+        this.onModeResized();
 
-        if (!PointerCapture._registeredEvents) {
-            Assert.assertIsDefined(Flashbang.pixi);
-            for (let eventType of PointerCapture.POINTER_EVENTS) {
-                Flashbang.pixi.renderer.plugins.interaction.addListener(eventType, PointerCapture.handleEvent);
+        this.addObject(this._surface, this.mode.container);
+
+        // We're not listening to over, out, or upOutside since a) those would refer to our surface,
+        // which isn't really meaningful, plus they're not providing the opportunity to prevent
+        // any events on lower objects - eg if you stop propogation on a pointerup, PIXI won't then
+        // continue to test children objects for a pointerUpOutside or pointerTap (pointerTap is
+        // still provided here for the convinience of wanting to know when the surface is tapped)
+        this.regs.add(this._surface.pointerDown.connect((e) => this.handleEvent(e)));
+        this.regs.add(this._surface.pointerMove.connect((e) => this.handleEvent(e)));
+        this.regs.add(this._surface.pointerUp.connect((e) => this.handleEvent(e)));
+        this.regs.add(this._surface.pointerCancel.connect((e) => this.handleEvent(e)));
+        this.regs.add(this._surface.pointerTap.connect((e) => this.handleEvent(e)));
+    }
+
+    public onModeResized() {
+        Assert.assertIsDefined(this.mode);
+        Assert.assertIsDefined(this.mode.container);
+        this._surface.display.clear()
+            .beginFill(0x0)
+            .drawRect(0, 0, this.mode.container.width, this.mode.container.height)
+            .endFill();
+    }
+
+    private handleEvent(e: InteractionEvent) {
+        Assert.assertIsDefined(Flashbang.app.pixi);
+        Assert.assertIsDefined(this.mode?.container);
+        const interaction = Flashbang.app.pixi.renderer.plugins.interaction;
+
+        this._surface.display.interactive = false;
+
+        let hitObj: DisplayObject | null = interaction.hitTest(e.data.global);
+        let isRootEvent = false;
+
+        while (hitObj != null) {
+            if (hitObj === this._root) {
+                isRootEvent = true;
+                break;
             }
-        }
-    }
-
-    private static handleEvent(e: InteractionEvent) {
-        Assert.assertIsDefined(Flashbang.pixi);
-        for (let capture of PointerCapture._captures.reverse()) {
-            if (!Flashbang.pixi.renderer.plugins.interaction.hitTest(e.data.global, capture._root)) {
-                Assert.assertIsDefined(capture._onEvent);
-                capture._onEvent(e);
-                if (e.stopped) return;
-            }
-        }
-    }
-
-    public endCapture(): void {
-        if (!this.hasCapture) {
-            return;
+            hitObj = hitObj.parent;
         }
 
-        this._onEvent = null;
-        this._root.interactive = this._rootWasInteractive;
-
-        PointerCapture._captures.splice(PointerCapture._captures.indexOf(this), 1);
-
-        if (PointerCapture._captures.length === 0) {
-            Assert.assertIsDefined(Flashbang.pixi);
-            for (let eventType of PointerCapture.POINTER_EVENTS) {
-                Flashbang.pixi.renderer.plugins.interaction.removeListener(eventType, PointerCapture.handleEvent);
-            }
+        if (!isRootEvent) {
+            this._onEvent(e);
         }
+
+        // Let event continue propagating to siblings
+        //
+        // Some very rough inspiration from https://github.com/pixijs/pixi.js/issues/2921#issuecomment-493801249
+        // Here be dragons, given that we're using internal portions of PIXI/turning off typechecking
+        // Hopefully https://github.com/pixijs/pixi.js/issues/6926 will be addressed so that we no longer
+        // need to do this.
+        //
+        // This should happen whether or not the event is related to the root object:
+        // - If it is, we need to rerun the processing so that the appropriate events are fired on
+        //   the right child of the root object.
+        // - If it isn't, processing should only stop if stopPropagation was called - PIXI's pointer
+        //   event processing atomatically handles that for us.
+
+        /* eslint-disable @typescript-eslint/ban-ts-ignore */
+
+        // @ts-ignore Not null
+        e.target = null;
+
+        let func;
+        switch (e.type) {
+            case 'pointerdown':
+                // @ts-ignore Private
+                func = interaction.processPointerDown;
+                break;
+            case 'pointermove':
+                // @ts-ignore Private
+                func = interaction.processPointerDown;
+                break;
+            case 'pointerup':
+                // @ts-ignore Private
+                func = interaction.processPointerUp;
+                break;
+            case 'pointercancel':
+                // @ts-ignore Private
+                func = interaction.processPointerCancel;
+                break;
+            default:
+                break;
+        }
+
+        // FIXME: This changed to public in Pixi 5.3, remove me once we upgrade
+        // @ts-ignore Protected
+        if (func != null) interaction.processInteractive(e, interaction.lastObjectRendered, func, true);
+
+        /* eslint-enable @typescript-eslint/ban-ts-ignore */
+
+        this._surface.display.interactive = true;
     }
 
-    private get hasCapture(): boolean {
-        return this._onEvent != null;
-    }
-
-    private readonly _root: Container;
-    private _onEvent: ((e: InteractionEvent) => void) | null;
-    private _rootWasInteractive: boolean;
-
-    private static _registeredEvents: boolean = false;
-    private static _captures: PointerCapture[] = [];
-
-    private static readonly POINTER_EVENTS: InteractionPointerEvents[] = [
-        'pointerdown', 'pointercancel', 'pointerup',
-        'pointertap', 'pointerupoutside', 'pointermove',
-        'pointerover', 'pointerout'
-    ];
+    private _root: Container;
+    private _surface: GraphicsObject;
+    private _onEvent: ((e: InteractionEvent) => void);
 }

--- a/src/flashbang/input/PointerTarget.ts
+++ b/src/flashbang/input/PointerTarget.ts
@@ -23,10 +23,10 @@ export default interface PointerTarget {
     /** Fired when a 'pointerup' event is dispatched on the object */
     pointerUp: SignalView<InteractionEvent>;
 
-    /** Fired when a 'pointerup' event is dispatched on the object */
+    /** Fired when a 'pointerupoutside' event is dispatched on the object */
     pointerUpOutside: SignalView<InteractionEvent>;
 
-    /** Fired when a 'pointerup' event is dispatched on the object */
+    /** Fired when a 'pointercancel' event is dispatched on the object */
     pointerCancel: SignalView<InteractionEvent>;
 
     /** Fired when a 'pointertap' event is dispatched on the object */

--- a/src/flashbang/input/PointerTarget.ts
+++ b/src/flashbang/input/PointerTarget.ts
@@ -23,6 +23,12 @@ export default interface PointerTarget {
     /** Fired when a 'pointerup' event is dispatched on the object */
     pointerUp: SignalView<InteractionEvent>;
 
+    /** Fired when a 'pointerup' event is dispatched on the object */
+    pointerUpOutside: SignalView<InteractionEvent>;
+
+    /** Fired when a 'pointerup' event is dispatched on the object */
+    pointerCancel: SignalView<InteractionEvent>;
+
     /** Fired when a 'pointertap' event is dispatched on the object */
     pointerTap: SignalView<InteractionEvent>;
 }

--- a/src/flashbang/layout/HLayoutContainer.ts
+++ b/src/flashbang/layout/HLayoutContainer.ts
@@ -96,6 +96,12 @@ export default class HLayoutContainer extends LayoutContainer {
                     child.y += maxHeight - bounds.height;
                 }
 
+                // This is an incredibly hacky setup for making sure menus are handled correctly
+                if (child.name?.startsWith('EternaMenu')) {
+                    let w = parseInt(child.name.replace('EternaMenu', ''), 10);
+                    bounds.width = w;
+                }
+
                 x += bounds.width + this._hOffset;
             }
         }

--- a/src/flashbang/layout/HLayoutContainer.ts
+++ b/src/flashbang/layout/HLayoutContainer.ts
@@ -1,6 +1,7 @@
 import {Rectangle} from 'pixi.js';
 import {VAlign} from 'flashbang/core/Align';
 import DisplayUtil from 'flashbang/util/DisplayUtil';
+import TrueWidthDisplay from 'eterna/ui/TrueWidthDisplay';
 import LayoutContainer from './LayoutContainer';
 
 /**
@@ -97,9 +98,8 @@ export default class HLayoutContainer extends LayoutContainer {
                 }
 
                 // This is an incredibly hacky setup for making sure menus are handled correctly
-                if (child.name?.startsWith('EternaMenu')) {
-                    let w = parseInt(child.name.replace('EternaMenu', ''), 10);
-                    bounds.width = w;
+                if (child.name === 'EternaMenu') {
+                    bounds.width = (child as TrueWidthDisplay).trueWidth;
                 }
 
                 x += bounds.width + this._hOffset;

--- a/src/flashbang/objects/GraphicsObject.ts
+++ b/src/flashbang/objects/GraphicsObject.ts
@@ -1,0 +1,9 @@
+import {Graphics} from 'pixi.js';
+import SceneObject from './SceneObject';
+
+/** A GameObject that manages a PIXI Graphics */
+export default class GraphicsObject extends SceneObject<Graphics> {
+    constructor(sprite?: Graphics) {
+        super(sprite || new Graphics());
+    }
+}

--- a/src/flashbang/objects/SceneObject.ts
+++ b/src/flashbang/objects/SceneObject.ts
@@ -41,6 +41,14 @@ export default class SceneObject<T extends DisplayObject = DisplayObject> extend
         return this.getPointerTarget().pointerUp;
     }
 
+    public get pointerUpOutside(): SignalView<InteractionEvent> {
+        return this.getPointerTarget().pointerUpOutside;
+    }
+
+    public get pointerCancel(): SignalView<InteractionEvent> {
+        return this.getPointerTarget().pointerCancel;
+    }
+
     public get pointerTap(): SignalView<InteractionEvent> {
         return this.getPointerTarget().pointerTap;
     }


### PR DESCRIPTION
Resolves #384 

This hides the zoom buttons (as is done on the app) on small screens and moves the palette up a row. If the screen is small enough, it also moves the mark bases and swap pairs buttons to the same row as the palette.