### PR TITLE
degradation data in FeedbackViewMode

### DIFF
--- a/src/eterna/Feedback.ts
+++ b/src/eterna/Feedback.ts
@@ -55,14 +55,28 @@ export default class Feedback {
     }
 
     public setShapeData(
-        dat: number[] | null, index: number,
+        dat: number[] | null, condition: string, index: number,
         threshold: number | null, max: number | null, min: number | null, failed: string | null
     ): void {
         if (dat != null) {
-            this._shapeStarts[index] = dat[0] - 1;
+            if (this._shapeStarts.get(condition) === undefined) {
+                this._shapeStarts.set(condition, []);
+            }
+            const shapeStarts = this._shapeStarts.get(condition);
+            if (shapeStarts !== undefined) {
+                shapeStarts[index] = dat[0] - 1;
+            }
+
             dat.splice(0, 1);
-            this._shapeData[index] = dat.slice();
-            let shapeData: number[] = this._shapeData[index];
+            if (this._shapeData.get(condition) === undefined) {
+                this._shapeData.set(condition, []);
+            }
+            let shapeDatas = this._shapeData.get(condition);
+            let shapeData: number[] = [];
+            if (shapeDatas !== undefined) {
+                shapeDatas[index] = dat.slice();
+                shapeData = shapeDatas[index];
+            }
 
             let smax: number = shapeData[0];
             let smin: number = shapeData[0];
@@ -84,31 +98,143 @@ export default class Feedback {
                 savg /= shapeData.length;
             }
 
-            if (threshold != null) {
-                this._shapeThresholds[index] = threshold;
-            } else {
-                this._shapeThresholds[index] = savg;
+            if (this._shapeThresholds.get(condition) === undefined) {
+                this._shapeThresholds.set(condition, []);
+            }
+            const shapeThreshold = this._shapeThresholds.get(condition);
+            if (threshold != null && shapeThreshold !== undefined) {
+                shapeThreshold[index] = threshold;
+            } else if (shapeThreshold !== undefined) {
+                shapeThreshold[index] = savg;
             }
 
-            if (max != null) {
-                this._shapeMaxs[index] = max;
-            } else {
-                this._shapeMaxs[index] = smax;
+            if (this._shapeMaxs.get(condition) === undefined) {
+                this._shapeMaxs.set(condition, []);
+            }
+            const shapeMaxs = this._shapeMaxs.get(condition);
+            if (max != null && shapeMaxs !== undefined) {
+                shapeMaxs[index] = max;
+            } else if (shapeMaxs !== undefined) {
+                shapeMaxs[index] = smax;
             }
 
-            if (min != null) {
-                this._shapeMins[index] = min;
-            } else {
-                this._shapeMins[index] = smin;
+            if (this._shapeMins.get(condition) === undefined) {
+                this._shapeMins.set(condition, []);
+            }
+            const shapeMins = this._shapeMins.get(condition);
+            if (shapeMins !== undefined) {
+                if (min != null) {
+                    shapeMins[index] = min;
+                } else if (shapeMins !== undefined) {
+                    shapeMins[index] = smin;
+                }
             }
         } else if (failed != null) {
-            this._faileds[index] = Feedback.EXPCODES[Feedback.EXPSTRINGS.indexOf(failed)];
+            if (this._faileds.get(condition) === undefined) {
+                this._faileds.set(condition, []);
+            }
+            const faileds = this._faileds.get(condition);
+            if (faileds !== undefined) {
+                faileds[index] = Feedback.EXPCODES[Feedback.EXPSTRINGS.indexOf(failed)];
+            }
         }
     }
 
-    public getShapeData(index: number = 0): number[] {
-        if (this._shapeData[index] != null) {
-            return this._shapeData[index];
+    public setDegradationData(
+        dat: number[] | null, condition: string, index: number,
+        error: number[] | null, stnCat: string | null, stn: number | null, failed: string | null
+    ): void {
+        if (dat != null) {
+            if (this._degradationStarts.get(condition) === undefined) {
+                this._degradationStarts.set(condition, []);
+            }
+            const degradationStarts = this._degradationStarts.get(condition);
+            if (degradationStarts !== undefined) {
+                degradationStarts[index] = dat[0] - 1;
+            }
+            dat.splice(0, 1);
+            if (this._degradationData.get(condition) === undefined) {
+                this._degradationData.set(condition, []);
+            }
+            const degradationDatas = this._degradationData.get(condition);
+            let degradationData: number[] = [];
+            if (degradationDatas !== undefined) {
+                degradationDatas[index] = dat.slice();
+                degradationData = degradationDatas[index];
+            }
+
+            let smax: number = degradationData[0];
+            let smin: number = degradationData[0];
+            let savg: number = degradationData[0];
+
+            for (let ii = 0; ii < degradationData.length; ii++) {
+                if (degradationData[ii] > smax) {
+                    smax = degradationData[ii];
+                }
+
+                if (degradationData[ii] < smin) {
+                    smin = degradationData[ii];
+                }
+
+                savg += degradationData[ii];
+            }
+
+            if (degradationData.length > 0) {
+                savg /= degradationData.length;
+            }
+
+            if (this._degradationThresholds.get(condition) === undefined) {
+                this._degradationThresholds.set(condition, []);
+            }
+            const degradationThreshold = this._degradationThresholds.get(condition);
+            // if (threshold != null && shapeThreshold !== undefined) {
+            //     shapeThreshold[index] = threshold;
+            // } else
+            if (degradationThreshold !== undefined) {
+                degradationThreshold[index] = savg;
+            }
+
+            if (this._degradationMaxs.get(condition) === undefined) {
+                this._degradationMaxs.set(condition, []);
+            }
+            const degradationMax = this._degradationMaxs.get(condition);
+            // if (max != null && shapeMaxs !== undefined) {
+            //     shapeMaxs[index] = max;
+            // } else
+            if (degradationMax !== undefined) {
+                degradationMax[index] = smax;
+            }
+
+            if (this._degradationMins.get(condition) === undefined) {
+                this._degradationMins.set(condition, []);
+            }
+            const degradationMin = this._degradationMins.get(condition);
+            // if (shapeMins !== undefined) {
+            //     if (min != null) {
+            //         shapeMins[index] = min;
+            //     } else
+            if (degradationMin !== undefined) {
+                degradationMin[index] = smin;
+            }
+            // }
+        } else if (failed != null) {
+            if (this._faileds.get(condition) === undefined) {
+                this._faileds.set(condition, []);
+            }
+            const faileds = this._faileds.get(condition);
+            if (faileds !== undefined) {
+                faileds[index] = Feedback.EXPCODES[Feedback.EXPSTRINGS.indexOf(failed)];
+            }
+        }
+    }
+
+    public getShapeData(index: number = 0, condition: string = 'SHAPE'): number[] {
+        const shapeData = this._shapeData.get(condition);
+        if (shapeData === undefined) {
+            return [0.5];
+        }
+        if (shapeData[index] != null) {
+            return shapeData[index];
         } else {
             let shape: number[] = [];
             shape.push(0.5);
@@ -116,36 +242,122 @@ export default class Feedback {
         }
     }
 
-    public getShapeStartIndex(index: number = 0): number {
-        if (this._shapeData[index] != null) return this._shapeStarts[index];
+    public getShapeStartIndex(index: number = 0, condition: string = 'SHAPE'): number {
+        const shapeStarts = this._shapeStarts.get(condition);
+        if (shapeStarts === undefined) {
+            return 0.5;
+        }
+        if (shapeStarts[index] != null) return shapeStarts[index];
         else return 0.5;
     }
 
-    public getShapeThreshold(index: number = 0): number {
-        if (this._shapeData[index] != null) return this._shapeThresholds[index];
+    public getShapeThreshold(index: number = 0, condition: string = 'SHAPE'): number {
+        const shapeThresholds = this._shapeThresholds.get(condition);
+        if (shapeThresholds === undefined) {
+            return 0.5;
+        }
+        if (shapeThresholds[index] != null) return shapeThresholds[index];
         else return 0.5;
     }
 
-    public getShapeMax(index: number = 0): number {
-        if (this._shapeData[index] != null) return this._shapeMaxs[index];
+    public getShapeMax(index: number = 0, condition: string = 'SHAPE'): number {
+        const shapeMaxs = this._shapeMaxs.get(condition);
+        if (shapeMaxs === undefined) {
+            return 1.0;
+        }
+        if (shapeMaxs[index] != null) return shapeMaxs[index];
         else return 1.0;
     }
 
-    public getShapeMin(index: number = 0): number {
-        if (this._shapeData[index] != null) return this._shapeMins[index];
+    public getShapeMin(index: number = 0, condition: string = 'SHAPE'): number {
+        const shapeMins = this._shapeMins.get(condition);
+        if (shapeMins === undefined) {
+            return 0.0;
+        }
+        if (shapeMins[index] != null) return shapeMins[index];
         else return 0.0;
     }
 
-    public isFailed(index: number = 0): number {
-        return index < this._faileds.length ? this._faileds[index] : 0;
+    public getDegradationData(index: number = 0, condition: string): number[] {
+        const degradationData = this._degradationData.get(condition);
+        if (degradationData === undefined) {
+            return [0.5];
+        }
+        if (degradationData[index] != null) {
+            return degradationData[index];
+        } else {
+            let shape: number[] = [];
+            shape.push(0.5);
+            return shape;
+        }
     }
 
-    private _shapeData: number[][] = [];
-    private _shapeStarts: number[] = [];
-    private _shapeThresholds: number[] = [];
-    private _shapeMaxs: number[] = [];
-    private _shapeMins: number[] = [];
-    private _faileds: number[] = [];
+    public getDegradationStartIndex(index: number = 0, condition: string): number {
+        const degradationStarts = this._degradationStarts.get(condition);
+        if (degradationStarts === undefined) {
+            return 0.5;
+        }
+        if (degradationStarts[index] != null) return degradationStarts[index];
+        else return 0.5;
+    }
+
+    public getDegradationThreshold(index: number = 0, condition: string): number {
+        const degradationThresholds = this._degradationThresholds.get(condition);
+        if (degradationThresholds === undefined) {
+            return 0.5;
+        }
+        if (degradationThresholds[index] != null) return degradationThresholds[index];
+        else return 0.5;
+    }
+
+    public getDegradationMax(index: number = 0, condition: string): number {
+        const degradationMaxs = this._degradationMaxs.get(condition);
+        if (degradationMaxs === undefined) {
+            return 1.0;
+        }
+        if (degradationMaxs[index] != null) return degradationMaxs[index];
+        else return 1.0;
+    }
+
+    public getDegradationMin(index: number = 0, condition: string): number {
+        const degradationMins = this._degradationMins.get(condition);
+        if (degradationMins === undefined) {
+            return 0.0;
+        }
+        if (degradationMins[index] != null) return degradationMins[index];
+        else return 0.0;
+    }
+
+    public isFailed(index: number = 0, condition: string = 'SHAPE'): number {
+        const faileds = this._faileds.get(condition);
+        if (faileds === undefined) {
+            return 0;
+        }
+        return index < faileds.length ? faileds[index] : 0;
+    }
+
+    public get conditions(): string[] {
+        let conds = ['SHAPE'];
+        console.error(this._degradationData.keys());
+        return Array.prototype.concat(conds, Array.from(this._degradationData.keys()));
+    }
+
+    private _shapeData: Map<string, number[][]> = new Map<string, number[][]>();
+    private _shapeStarts: Map<string, number[]> = new Map<string, number[]>();
+    private _shapeThresholds: Map<string, number[]> = new Map<string, number[]>();
+    private _shapeMaxs: Map<string, number[]> = new Map<string, number[]>();
+    private _shapeMins: Map<string, number[]> = new Map<string, number[]>();
+
+    private _degradationData: Map<string, number[][]> = new Map<string, number[][]>();
+    private _degradationStarts: Map<string, number[]> = new Map<string, number[]>();
+    private _degradationThresholds: Map<string, number[]> = new Map<string, number[]>();
+    private _degradationMaxs: Map<string, number[]> = new Map<string, number[]>();
+    private _degradationMins: Map<string, number[]> = new Map<string, number[]>();
+    private _degradationErrors: Map<string, number[][]> = new Map<string, number[][]>();
+    private _degradationStnCats: Map<string, string[]> = new Map<string, string[]>();
+    private _degradationStns: Map<string, number[]> = new Map<string, number[]>();
+
+    private _faileds: Map<string, number[]> = new Map<string, number[]>();
     // / Ad-hoc data storage object for Brent's theophylline puzzle
     private _brentTheoData: BrentTheoData | undefined = undefined;
 }

--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -19,18 +19,17 @@ import {
     VAlign, HAlign, DisplayUtil, KeyboardEventType, KeyCode, Assert
 } from 'flashbang';
 import EternaViewOptionsDialog, {EternaViewOptionsMode} from 'eterna/ui/EternaViewOptionsDialog';
-import Utility from 'eterna/util/Utility';
 import SpecBoxDialog from 'eterna/ui/SpecBoxDialog';
 import Folder from 'eterna/folding/Folder';
-import URLButton from 'eterna/ui/URLButton';
 import Bitmaps from 'eterna/resources/Bitmaps';
 import GameButton from 'eterna/ui/GameButton';
 import EternaURL from 'eterna/net/EternaURL';
 import BitmapManager from 'eterna/resources/BitmapManager';
 import HTMLTextObject from 'eterna/ui/HTMLTextObject';
+import GameDropdown from 'eterna/ui/GameDropdown';
+import {MappedValue, ValueView} from 'signals';
 import GameMode from './GameMode';
 import ViewSolutionOverlay from './DesignBrowser/ViewSolutionOverlay';
-import DesignBrowserMode from './DesignBrowser/DesignBrowserMode';
 
 enum PoseFoldMode {
     ESTIMATE = 'ESTIMATE',
@@ -203,6 +202,28 @@ export default class FeedbackViewMode extends GameMode {
         this.addObject(this._info, this.uiLayer);
 
         this.setPoseFields(poseFields);
+
+        this._dropdown = new GameDropdown(
+            14,
+            this._solution.expFeedback?.conditions ?? ['SHAPE'],
+            'SHAPE',
+            0
+        );
+
+        this._dropdown.disabled = false;
+        this._dropdown.selectedOption.connect(() => this.showExperimentalColors());
+
+        // for now this is fine; we turn the dropdown options
+        // into themselves. that's all we need to access the JSON
+        // of data we will receive (or not)
+        this._dataOption = MappedValue.create(
+            this._dropdown.selectedOption,
+            (name) => name
+        );
+
+        this.addObject(this._dropdown, this.uiLayer);
+        this._dropdown.display.position = new Point(18, 50);
+
         let seeShape: boolean = (this._feedback !== null && this._feedback.getShapeData() != null);
         if (seeShape) {
             this.setupShape();
@@ -484,23 +505,44 @@ export default class FeedbackViewMode extends GameMode {
         this._toolbar.letterColorButton.toggled.value = false;
         this._toolbar.expColorButton.toggled.value = true;
 
-        if (this._isPipMode) {
+        console.error(this._dataOption.value);
+        if (this._dataOption.value === 'SHAPE') {
+            if (this._isPipMode) {
+                for (let ii = 0; ii < this._poseFields.length; ii++) {
+                    this._poseFields[ii].pose.visualizeFeedback(
+                        this._feedback.getShapeData(ii, this._dataOption.value),
+                        this._feedback.getShapeThreshold(ii, this._dataOption.value),
+                        this._feedback.getShapeMin(ii, this._dataOption.value),
+                        this._feedback.getShapeMax(ii, this._dataOption.value),
+                        this._feedback.getShapeStartIndex(ii, this._dataOption.value)
+                    );
+                }
+            } else {
+                this._poseFields[0].pose.visualizeFeedback(
+                    this._feedback.getShapeData(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeThreshold(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeMin(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeMax(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeStartIndex(this._currentIndex, this._dataOption.value)
+                );
+            }
+        } else if (this._isPipMode) {
             for (let ii = 0; ii < this._poseFields.length; ii++) {
                 this._poseFields[ii].pose.visualizeFeedback(
-                    this._feedback.getShapeData(ii),
-                    this._feedback.getShapeThreshold(ii),
-                    this._feedback.getShapeMin(ii),
-                    this._feedback.getShapeMax(ii),
-                    this._feedback.getShapeStartIndex(ii)
+                    this._feedback.getDegradationData(ii, this._dataOption.value),
+                    this._feedback.getDegradationThreshold(ii, this._dataOption.value),
+                    this._feedback.getDegradationMin(ii, this._dataOption.value),
+                    this._feedback.getDegradationMax(ii, this._dataOption.value),
+                    this._feedback.getDegradationStartIndex(ii, this._dataOption.value)
                 );
             }
         } else {
             this._poseFields[0].pose.visualizeFeedback(
-                this._feedback.getShapeData(this._currentIndex),
-                this._feedback.getShapeThreshold(this._currentIndex),
-                this._feedback.getShapeMin(this._currentIndex),
-                this._feedback.getShapeMax(this._currentIndex),
-                this._feedback.getShapeStartIndex(this._currentIndex)
+                this._feedback.getDegradationData(this._currentIndex, this._dataOption.value),
+                this._feedback.getDegradationThreshold(this._currentIndex, this._dataOption.value),
+                this._feedback.getDegradationMin(this._currentIndex, this._dataOption.value),
+                this._feedback.getDegradationMax(this._currentIndex, this._dataOption.value),
+                this._feedback.getDegradationStartIndex(this._currentIndex, this._dataOption.value)
             );
         }
     }
@@ -531,12 +573,12 @@ export default class FeedbackViewMode extends GameMode {
             // / Default fallback to usual SHAPE data
             if (Eterna.DEV_MODE) {
                 score = Feedback.scoreFeedback(
-                    this._feedback.getShapeData(this._currentIndex),
+                    this._feedback.getShapeData(this._currentIndex, this._dataOption.value),
                     this._puzzle.getSecstruct(this._currentIndex),
-                    this._feedback.getShapeStartIndex(this._currentIndex),
-                    this._feedback.getShapeMin(this._currentIndex),
-                    this._feedback.getShapeThreshold(this._currentIndex),
-                    this._feedback.getShapeMax(this._currentIndex)
+                    this._feedback.getShapeStartIndex(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeMin(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeThreshold(this._currentIndex, this._dataOption.value),
+                    this._feedback.getShapeMax(this._currentIndex, this._dataOption.value)
                 );
                 titleText += (`${this._solution.title}\nSynthesis score : ${score} / 100`);
             } else {
@@ -551,12 +593,12 @@ export default class FeedbackViewMode extends GameMode {
                     }
 
                     score = Feedback.scoreFeedback(
-                        this._feedback.getShapeData(ii),
+                        this._feedback.getShapeData(ii, this._dataOption.value),
                         this._puzzle.getSecstruct(ii),
-                        this._feedback.getShapeStartIndex(ii),
-                        this._feedback.getShapeMin(ii),
-                        this._feedback.getShapeThreshold(ii),
-                        this._feedback.getShapeMax(ii)
+                        this._feedback.getShapeStartIndex(ii, this._dataOption.value),
+                        this._feedback.getShapeMin(ii, this._dataOption.value),
+                        this._feedback.getShapeThreshold(ii, this._dataOption.value),
+                        this._feedback.getShapeMax(ii, this._dataOption.value)
                     );
 
                     titleText += `state ${ii + 1} : ${score} / 100`;
@@ -684,4 +726,6 @@ export default class FeedbackViewMode extends GameMode {
     private _isExpColor: boolean;
     private _solutionView?: ViewSolutionOverlay;
     private _info: GameButton;
+    private _dropdown: GameDropdown;
+    private _dataOption: ValueView<string>;
 }


### PR DESCRIPTION
I'm sure it could be more beautiful, and I'm currently ignoring the (not relevant for coloring) signal to noise data. I am sure we could just put them in a text box somewhere.

One pain of course is that the schema doesn't quite match between degradation data and other shape data. Confronted with the choice of either splitting all the behavior of all our functions (s.t. `getShapeMins` could do one of two things) and splitting the data itself into two buckets, I did the latter.