### PR TITLE
Remove overlap limitation and increase max bases in puzzlemaker

### DIFF
--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -736,7 +736,7 @@ export default class PuzzleEditMode extends GameMode {
         for (let ii = 0; ii < this._poses.length; ii++) {
             const secstruct: string = this._structureInputs[ii].structureString;
 
-            const lengthLimit = Eterna.DEV_MODE ? -1 : 400;
+            const lengthLimit = Eterna.DEV_MODE ? -1 : 4000;
 
             const error: string | null = EPars.validateParenthesis(secstruct, false, lengthLimit);
             if (error != null) {
@@ -746,11 +746,6 @@ export default class PuzzleEditMode extends GameMode {
 
             if (secstruct.length !== firstSecstruct.length) {
                 this.showNotification("Structure lengths don't match");
-                return;
-            }
-
-            if (this._poses[ii].checkOverlap() && !Eterna.DEV_MODE) {
-                this.showNotification('Some bases overlapped too much!');
                 return;
             }
         }


### PR DESCRIPTION
Now that we have tools for handling overlaps, improved performance, engines in the Linearfold family, and labs that require design of long RNA, it seems appropriate for us to loosen these restrictions in puzzlemaker