### PR TITLE
Fix multistrand/oligo bugs

### DIFF
--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -2,13 +2,13 @@ import {Assert} from 'flashbang';
 import {RNABase} from 'eterna/EPars';
 import Plot, {PlotType} from 'eterna/Plot';
 import {AnnotationData} from 'eterna/AnnotationManager';
-import Pose2D, {Oligo} from './pose2D/Pose2D';
 import Folder from './folding/Folder';
 import Utility from './util/Utility';
 import Vienna from './folding/Vienna';
 import Vienna2 from './folding/Vienna2';
 import FolderManager from './folding/FolderManager';
 import DotPlot from './rnatypes/DotPlot';
+import {Oligo, OligoMode} from './rnatypes/Oligo';
 import SecStruct from './rnatypes/SecStruct';
 import Sequence from './rnatypes/Sequence';
 import {TargetType} from './puzzle/Puzzle';
@@ -309,7 +309,7 @@ export default class UndoBlock {
     public get oligoMode(): number {
         const tc: TargetConditions | undefined = this.targetConditions;
         if (tc === undefined) return 0;
-        return tc['fold_mode'] === undefined ? Pose2D.OLIGO_MODE_DIMER : Number(tc['fold_mode']);
+        return tc['fold_mode'] === undefined ? OligoMode.DIMER : Number(tc['fold_mode']);
     }
 
     public get oligoName(): string | undefined {
@@ -456,8 +456,8 @@ export default class UndoBlock {
 
         let fullSeq: RNABase[] = seq.baseArray.slice();
         if (this._targetOligo) {
-            if (this.oligoMode === Pose2D.OLIGO_MODE_DIMER) fullSeq.push(RNABase.CUT);
-            if (this.oligoMode === Pose2D.OLIGO_MODE_EXT5P) {
+            if (this.oligoMode === OligoMode.DIMER) fullSeq.push(RNABase.CUT);
+            if (this.oligoMode === OligoMode.EXT5P) {
                 fullSeq = this._targetOligo.concat(fullSeq);
             } else {
                 fullSeq = fullSeq.concat(this._targetOligo);
@@ -709,7 +709,7 @@ export default class UndoBlock {
     }
 
     /**
-     * Return map of current base indices to adjusted base indices when oligos are rearranged
+     * Return map of adjusted base indices to original base indices when oligos are rearranged
      * according to otherorder
      * @param otherOrder An array of indexes, where the index refers to the new index
      * the oligo at the given position in the old array should be placed at.

--- a/src/eterna/folding/Folder.ts
+++ b/src/eterna/folding/Folder.ts
@@ -1,5 +1,5 @@
 import PoseOp from 'eterna/pose2D/PoseOp';
-import {Oligo} from 'eterna/pose2D/Pose2D';
+import {Oligo} from 'eterna/rnatypes/Oligo';
 import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -3,7 +3,7 @@ import {RNABase} from 'eterna/EPars';
 import EmscriptenUtil from 'eterna/emscripten/EmscriptenUtil';
 import PoseOp from 'eterna/pose2D/PoseOp';
 import int from 'eterna/util/int';
-import {Oligo} from 'eterna/pose2D/Pose2D';
+import {Oligo} from 'eterna/rnatypes/Oligo';
 import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -27,9 +27,7 @@ import FolderManager from 'eterna/folding/FolderManager';
 import Folder, {MultiFoldResult, CacheKey} from 'eterna/folding/Folder';
 import {PaletteTargetType, GetPaletteTargetBaseType} from 'eterna/ui/NucleotidePalette';
 import PoseField from 'eterna/pose2D/PoseField';
-import Pose2D, {
-    Oligo, Layout, SCRIPT_MARKER_LAYER
-} from 'eterna/pose2D/Pose2D';
+import Pose2D, {Layout, SCRIPT_MARKER_LAYER} from 'eterna/pose2D/Pose2D';
 import PuzzleEditOp from 'eterna/pose2D/PuzzleEditOp';
 import BitmapManager from 'eterna/resources/BitmapManager';
 import ConstraintBar from 'eterna/constraints/ConstraintBar';
@@ -59,6 +57,7 @@ import {RankScrollData} from 'eterna/rank/RankScroll';
 import FolderSwitcher from 'eterna/ui/FolderSwitcher';
 import MarkerSwitcher from 'eterna/ui/MarkerSwitcher';
 import DotPlot from 'eterna/rnatypes/DotPlot';
+import {Oligo, OligoMode} from 'eterna/rnatypes/Oligo';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 import UITheme from 'eterna/ui/UITheme';
@@ -675,11 +674,13 @@ export default class PoseEditMode extends GameMode {
 
                 const currBlock = this.getCurrentUndoBlock(poseState);
                 const naturalMap = currBlock.reorderedOligosIndexMap(currBlock.oligoOrder);
-                const ranges = (this._poseState === PoseState.NATIVE && naturalMap !== undefined)
-                    ? highlightInfo.ranges.map((index: number) => {
-                        Assert.assertIsDefined(naturalMap);
-                        return naturalMap.indexOf(index);
-                    }) : highlightInfo.ranges;
+                const targetMap = currBlock.reorderedOligosIndexMap(currBlock.targetOligoOrder);
+                let ranges = highlightInfo.ranges;
+                if (this._poseState === PoseState.NATIVE && naturalMap !== undefined) {
+                    ranges = highlightInfo.ranges.map((index: number) => naturalMap.indexOf(index));
+                } else if (this._poseState === PoseState.TARGET && targetMap !== undefined) {
+                    ranges = highlightInfo.ranges.map((index: number) => targetMap.indexOf(index));
+                }
 
                 switch (highlightInfo.color) {
                     case HighlightType.RESTRICTED:
@@ -791,7 +792,7 @@ export default class PoseEditMode extends GameMode {
             if (tc['oligo_sequence']) {
                 this._targetOligo[ii] = Sequence.fromSequenceString(tc['oligo_sequence'] as string).baseArray;
                 this._oligoMode[ii] = tc['fold_mode'] === undefined
-                    ? Pose2D.OLIGO_MODE_DIMER
+                    ? OligoMode.DIMER
                     : Number(tc['fold_mode']);
                 this._oligoName[ii] = tc['oligo_name'];
             }
@@ -1696,7 +1697,7 @@ export default class PoseEditMode extends GameMode {
 
             if (Puzzle.isOligoType(tcType)) {
                 const foldMode: number = tc['fold_mode'] === undefined
-                    ? Pose2D.OLIGO_MODE_DIMER
+                    ? OligoMode.DIMER
                     : Number(tc['fold_mode']);
                 this._poses[poseIndex].setOligo(
                     Sequence.fromSequenceString(tc['oligo_sequence'] as string).baseArray,
@@ -2461,7 +2462,7 @@ export default class PoseEditMode extends GameMode {
 
         if (this._targetConditions[0] && Puzzle.isOligoType(this._targetConditions[0]['type'])) {
             oligoLen = (this._targetConditions[0]['oligo_sequence'] as string).length;
-            if (Number(this._targetConditions[0]['fold_mode']) === Pose2D.OLIGO_MODE_DIMER) oligoLen++;
+            if (Number(this._targetConditions[0]['fold_mode']) === OligoMode.DIMER) oligoLen++;
         } else if (this._targetConditions[0] && this._targetConditions[0]['type'] === 'multistrand') {
             const oligos: OligoDef[] = this._targetConditions[0]['oligos'] as OligoDef[];
             for (const oligo of oligos) {
@@ -3128,14 +3129,14 @@ export default class PoseEditMode extends GameMode {
             );
         } else if ((tc as TargetConditions)['type'] === 'oligo') {
             foldMode = (tc as TargetConditions)['fold_mode'] === undefined
-                ? Pose2D.OLIGO_MODE_DIMER
+                ? OligoMode.DIMER
                 : Number(tc['fold_mode']);
-            if (foldMode === Pose2D.OLIGO_MODE_DIMER) {
+            if (foldMode === OligoMode.DIMER) {
                 log.debug('cofold');
                 const fullSeq = seq.concat(Sequence.fromSequenceString(`&${tc['oligo_sequence']}`));
                 malus = int(tc['malus'] as number * 100);
                 bestPairs = this._folder.cofoldSequence(fullSeq, null, malus, forceStruct);
-            } else if (foldMode === Pose2D.OLIGO_MODE_EXT5P) {
+            } else if (foldMode === OligoMode.EXT5P) {
                 const fullSeq = Sequence.fromSequenceString(tc['oligo_sequence'] as string).concat(seq);
                 bestPairs = this._folder.foldSequence(fullSeq, null, forceStruct);
             } else {
@@ -3146,16 +3147,16 @@ export default class PoseEditMode extends GameMode {
             bonus = tc['bonus'] as number;
             sites = tc['site'] as number[];
             foldMode = tc['fold_mode'] === undefined
-                ? Pose2D.OLIGO_MODE_DIMER
+                ? OligoMode.DIMER
                 : Number(tc['fold_mode']);
-            if (foldMode === Pose2D.OLIGO_MODE_DIMER) {
+            if (foldMode === OligoMode.DIMER) {
                 log.debug('cofold');
                 const fullSeq = seq.concat(Sequence.fromSequenceString(`&${tc['oligo_sequence']}`));
                 malus = int(tc['malus'] as number * 100);
                 bestPairs = this._folder.cofoldSequenceWithBindingSite(
                     fullSeq, sites, bonus, forceStruct, malus
                 );
-            } else if (foldMode === Pose2D.OLIGO_MODE_EXT5P) {
+            } else if (foldMode === OligoMode.EXT5P) {
                 const fullSeq = Sequence.fromSequenceString(tc['oligo_sequence'] as string).concat(seq);
                 bestPairs = this._folder.foldSequenceWithBindingSite(
                     fullSeq, this._targetPairs[ii], sites, Number(bonus), tc['fold_version']

--- a/src/eterna/puzzle/Puzzle.ts
+++ b/src/eterna/puzzle/Puzzle.ts
@@ -4,7 +4,6 @@ import FolderManager from 'eterna/folding/FolderManager';
 import Vienna from 'eterna/folding/Vienna';
 import Folder from 'eterna/folding/Folder';
 import EternaURL from 'eterna/net/EternaURL';
-import Pose2D from 'eterna/pose2D/Pose2D';
 import Constraint, {BaseConstraintStatus} from 'eterna/constraints/Constraint';
 import ShapeConstraint from 'eterna/constraints/constraints/ShapeConstraint';
 import {TargetConditions, OligoDef} from 'eterna/UndoBlock';
@@ -12,6 +11,7 @@ import {BoosterData} from 'eterna/mode/PoseEdit/Booster';
 import Utility from 'eterna/util/Utility';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
+import {OligoMode} from 'eterna/rnatypes/Oligo';
 
 export interface BoostersData {
     mission?: Mission;
@@ -263,7 +263,7 @@ export default class Puzzle {
                 Puzzle.isOligoType(tcType)
                 && Object.hasOwnProperty.call(this._targetConditions[ii], 'fold_mode') === false
             ) {
-                this._targetConditions[ii]['fold_mode'] = Pose2D.OLIGO_MODE_DIMER.toString();
+                this._targetConditions[ii]['fold_mode'] = OligoMode.DIMER.toString();
             }
 
             if (Puzzle.isOligoType(tcType) && this._targetConditions[ii]['oligo_sequence'] != null) {

--- a/src/eterna/rnatypes/Oligo.ts
+++ b/src/eterna/rnatypes/Oligo.ts
@@ -1,0 +1,11 @@
+export interface Oligo {
+    malus: number;
+    name?: string;
+    sequence: number[];
+}
+
+export enum OligoMode {
+    DIMER = 1,
+    EXT3P = 2,
+    EXT5P = 3
+}


### PR DESCRIPTION
* Fix comment on reorderedOligosIndexMap, which described the map as going in the wrong direction
* Fix shape constraint _targetAlignedConstraints and _targetAlignedNaturalPairs which used the backwards interpretation of reorderedOligosIndexMap
* Fix delta energy calculation in multistrand puzzles, where the oligo order of the pose was always used for the sequence rather than the desired target/native oligo order (which could also cause a crash)
* Change Oligo mode from static members to enum
* Create new rnatypes file for Oligo and OligoMode
* Fix sequence highlights not respecting target oligo order in target mode (namely for binding and shape constraints)