### PR TITLE
adding nupack functions for subopt structures and energies

### DIFF
--- a/lib/NUPACK/CMakeLists.txt
+++ b/lib/NUPACK/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(nupack
         emscripten/Bindings.cpp
         emscripten/FullEval.cpp
         emscripten/FullFold.cpp
+        emscripten/FullEnsemble.cpp
         ../emscripten_common/EmscriptenUtils.cpp)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")

--- a/lib/NUPACK/emscripten/Bindings.cpp
+++ b/lib/NUPACK/emscripten/Bindings.cpp
@@ -64,11 +64,13 @@ EMSCRIPTEN_BINDINGS(EmscriptenBridge) {
 
     class_<FullAdvancedResult>("FullAdvancedResult")
         .property("ensembleDefect", &FullAdvancedResult::ensembleDefect)
-        .property("subopt_structures", &FullAdvancedResult::subopt_structures)
-        .property("subopt_energyError", &FullAdvancedResult::subopt_energyError)
-        .property("subopt_freeEnergy", &FullAdvancedResult::subopt_freeEnergy);
+        .property("suboptStructures", &FullAdvancedResult::suboptStructures)
+        .property("suboptEnergyError", &FullAdvancedResult::suboptEnergyError)
+        .property("suboptFreeEnergy", &FullAdvancedResult::suboptFreeEnergy);
 
     function("FullEnsembleNoBindingSite", &FullEnsembleNoBindingSite, allow_raw_pointers());
+    function("FullEnsembleWithOligos", &FullEnsembleWithOligos, allow_raw_pointers());
+
 
 }
 

--- a/lib/NUPACK/emscripten/Bindings.cpp
+++ b/lib/NUPACK/emscripten/Bindings.cpp
@@ -1,5 +1,6 @@
 #include "FullEval.h"
 #include "FullFold.h"
+#include "FullEnsemble.h"
 
 #include "src/thermo/utils/pfuncUtilsConstants.h"
 #include "src/thermo/utils/pfuncUtilsHeader.h"
@@ -35,6 +36,8 @@ using namespace emscripten;
 EMSCRIPTEN_BINDINGS(EmscriptenBridge) {
     register_vector<int>("VectorInt");
     register_vector<double>("VectorDouble");
+    register_vector<std::string>("VectorString");
+    
 
     class_<FullEvalResult>("FullEvalResult")
         .constructor()
@@ -58,6 +61,15 @@ EMSCRIPTEN_BINDINGS(EmscriptenBridge) {
         .property("plot", &DotPlotResult::plot);
 
     function("GetDotPlot", &GetDotPlot, allow_raw_pointers());
+
+    class_<FullAdvancedResult>("FullAdvancedResult")
+        .property("ensembleDefect", &FullAdvancedResult::ensembleDefect)
+        .property("subopt_structures", &FullAdvancedResult::subopt_structures)
+        .property("subopt_energyError", &FullAdvancedResult::subopt_energyError)
+        .property("subopt_freeEnergy", &FullAdvancedResult::subopt_freeEnergy);
+
+    function("FullEnsembleNoBindingSite", &FullEnsembleNoBindingSite, allow_raw_pointers());
+
 }
 
 #endif

--- a/lib/NUPACK/emscripten/FullEnsemble.cpp
+++ b/lib/NUPACK/emscripten/FullEnsemble.cpp
@@ -10,25 +10,166 @@
 #include <string> 
 
 
-FullAdvancedResult* FullEnsembleNoBindingSite(const std::string& seqString, int temperature, float kcal_delta_range_mfe_subopt, bool const pseudoknotted = false)
+FullAdvancedResult* FullEnsembleWithOligos(const std::string& seqString, int temperature, float kcalDeltaRange, bool const pseudoknotted = false)
 {
 
+    //this chuck of code sets up the variables used to represent adn configure the sequence for the C code to use
     auto autoSeqString = MakeCString(seqString);
     char* string = autoSeqString.get();
-
     int seqNum[MAXSEQLENGTH+1];
-    int tmpLength = strlen(string);
-    dnaStructures suboptStructs = {NULL, 0, 0, 0, 0};
+    
 
-    convertSeq(string, seqNum, tmpLength);
-    //first get teh ensemble through subopt
+
+    //runtime_constants.h defines NAD_INFINITY
+    //#define NAD_INFINITY 100000 //artificial value for positive infinity
+    //this is how teh dnastructure call looks for subopt.c which is waht iran when you ron normal nupack compiled code
+    //here are comments from pfuncutilheaders.h on hwat the attributes of dnastructures consist of
+    
+    //oneDnaStruct and dnaStructures are used for enumerating sequences
+       // typedef struct {
+       // int *theStruct; //describes what is paired to what
+       // DBL_TYPE error; //accumulated error (from the mfe) for a structure
+       // DBL_TYPE correctedEnergy; //actual energy of a structure
+       // int slength;
+       // //(accounting for symmetry).
+       //  } oneDnaStruct;
+       //
+       // typedef struct {
+       // oneDnaStruct *validStructs;
+       //int nStructs; //# of structures stored
+       //int nAlloc; //# of structures allocated
+       // int seqlength;
+       // DBL_TYPE minError; //minimum deviation from mfe for all seqs
+       //in validStructs
+       //
+       //} dnaStructures;
+    
+    //this struct will store
+    //all the structures within the given range
+    dnaStructures suboptStructs = {NULL, 0, 0, 0, NAD_INFINITY}; 
+ 
+    //convert from how it comes from eterna to how nuapck needs it for joined oligos '+'
+    char* pc;
+    do {
+        pc = strchr(string, '&');
+        if (pc) (*pc) = '+';
+    } while(pc);
+  
+
+    int seqStringLength = strlen(string);    
+    convertSeq(string, seqNum, seqStringLength);
+  
+
+    //first get the ensemble through subopt
     if ( pseudoknotted ) {
-        mfeFullWithSym_SubOpt(seqNum, tmpLength, &suboptStructs, 5, RNA, 1 /*DANGLETYPE*/, 
-                                temperature, TRUE, (DBL_TYPE) kcal_delta_range_mfe_subopt, 
+        mfeFullWithSym_SubOpt(seqNum, seqStringLength, &suboptStructs, 5, RNA, 1 /*DANGLETYPE*/, 
+                                temperature, TRUE, (DBL_TYPE) kcalDeltaRange, 
                                 0, SODIUM_CONC, MAGNESIUM_CONC, USE_LONG_HELIX_FOR_SALT_CORRECTION);
     } else {
-        mfeFullWithSym_SubOpt(seqNum, tmpLength, &suboptStructs, 3, RNA, 1 /*DANGLETYPE*/, 
-                                temperature, TRUE, (DBL_TYPE) kcal_delta_range_mfe_subopt, 
+        mfeFullWithSym_SubOpt(seqNum, seqStringLength, &suboptStructs, 3, RNA, 1 /*DANGLETYPE*/, 
+                                temperature, TRUE, (DBL_TYPE) kcalDeltaRange, 
+                                0, SODIUM_CONC, MAGNESIUM_CONC, USE_LONG_HELIX_FOR_SALT_CORRECTION);
+    }
+
+    //initialize the result to return
+    FullAdvancedResult* result = new FullAdvancedResult();
+    
+    int i, j;
+    //get dot bracket notation from data 
+    for (i = 0; i < suboptStructs.nStructs; i++ ) {
+        oneDnaStruct currentStruct = suboptStructs.validStructs[i];
+
+        //each structure reset this
+        std::string singlestructure = "";             
+        for (j = 0; j < suboptStructs.seqlength; j++ ) {
+            if( currentStruct.theStruct[j] > j ) {
+                singlestructure.push_back('(');
+            }
+            else if ( currentStruct.theStruct[j] == -1 ) {
+                singlestructure.push_back('.');
+            }
+            else singlestructure.push_back(')');
+        }  
+
+        
+        std::string constraints = singlestructure;
+        for (pc = string, i = 0, j = 0; (*pc); pc++, j++) {
+            auto value = ((*pc) == '+' ? '&' : constraints[i++]);
+            if (j < singlestructure.length()) {
+                singlestructure[j] = value;
+            } else {
+                singlestructure.push_back(value);
+            }
+        }
+
+        //get energies
+        double energyError = currentStruct.error;
+        double correctedEnergy = currentStruct.correctedEnergy;  
+        
+
+        //write out data
+        result->suboptStructures.push_back(singlestructure);
+        result->suboptEnergyError.push_back(energyError);
+        result->suboptFreeEnergy.push_back(correctedEnergy);
+    }
+
+    clearDnaStructures(&suboptStructs);
+
+    //get defect here later for now popuolate with 0
+    result->ensembleDefect=0;
+
+
+    return result;
+}
+
+
+FullAdvancedResult* FullEnsembleNoBindingSite(const std::string& seqString, int temperature, float kcalDeltaRange, bool const pseudoknotted = false)
+{
+
+    //this chuck of code sets up the variables used to represent adn configure the sequence for the C code to use
+    auto autoSeqString = MakeCString(seqString);
+    char* string = autoSeqString.get();
+    int seqNum[MAXSEQLENGTH+1];
+    int seqStringLength = strlen(string);
+    //runtime_constants.h defines NAD_INFINITY
+    //#define NAD_INFINITY 100000 //artificial value for positive infinity
+    //this is how teh dnastructure call looks for subopt.c which is waht iran when you ron normal nupack compiled code
+    //here are comments from pfuncutilheaders.h on hwat the attributes of dnastructures consist of
+    
+    //oneDnaStruct and dnaStructures are used for enumerating sequences
+       // typedef struct {
+       // int *theStruct; //describes what is paired to what
+       // DBL_TYPE error; //accumulated error (from the mfe) for a structure
+       // DBL_TYPE correctedEnergy; //actual energy of a structure
+       // int slength;
+       // //(accounting for symmetry).
+       //  } oneDnaStruct;
+       //
+       // typedef struct {
+       // oneDnaStruct *validStructs;
+       //int nStructs; //# of structures stored
+       //int nAlloc; //# of structures allocated
+       // int seqlength;
+       // DBL_TYPE minError; //minimum deviation from mfe for all seqs
+       //in validStructs
+       //
+       //} dnaStructures;
+    
+    //this struct will store
+    //all the structures within the given range
+    dnaStructures suboptStructs = {NULL, 0, 0, 0, NAD_INFINITY};     
+    convertSeq(string, seqNum, seqStringLength);
+
+
+
+    //first get the ensemble through subopt
+    if ( pseudoknotted ) {
+        mfeFullWithSym_SubOpt(seqNum, seqStringLength, &suboptStructs, 5, RNA, 1 /*DANGLETYPE*/, 
+                                temperature, TRUE, (DBL_TYPE) kcalDeltaRange, 
+                                0, SODIUM_CONC, MAGNESIUM_CONC, USE_LONG_HELIX_FOR_SALT_CORRECTION);
+    } else {
+        mfeFullWithSym_SubOpt(seqNum, seqStringLength, &suboptStructs, 3, RNA, 1 /*DANGLETYPE*/, 
+                                temperature, TRUE, (DBL_TYPE) kcalDeltaRange, 
                                 0, SODIUM_CONC, MAGNESIUM_CONC, USE_LONG_HELIX_FOR_SALT_CORRECTION);
     }
 
@@ -37,35 +178,38 @@ FullAdvancedResult* FullEnsembleNoBindingSite(const std::string& seqString, int 
     
     
     //get dot bracket notation from data 
-    for(int i = 0; i < suboptStructs.nStructs; i++) {
+    for ( int i = 0; i < suboptStructs.nStructs; i++ ) {
+        oneDnaStruct currentStruct = suboptStructs.validStructs[i];
+
         //each structure reset this
         std::string singlestructure = "";             
-        for(int j = 0; j < suboptStructs.seqlength; j++) {
-            if(suboptStructs.validStructs[i].theStruct[j] > j) {
+        for ( int j = 0; j < suboptStructs.seqlength; j++ ) {
+            if( currentStruct.theStruct[j] > j ) {
                 singlestructure.push_back('(');
             }
-            else if(suboptStructs.validStructs[i].theStruct[j] == -1 ) {
+            else if ( currentStruct.theStruct[j] == -1 ) {
                 singlestructure.push_back('.');
             }
             else singlestructure.push_back(')');
         }  
         //get energies
-        std::string energyError = std::to_string(suboptStructs.validStructs[i].error);
-        std::string correctedEnergy = std::to_string(suboptStructs.validStructs[i].correctedEnergy);  
+        double energyError = currentStruct.error;
+        double correctedEnergy = currentStruct.correctedEnergy;  
         
 
         //write out data
-        result-> subopt_structures.push_back(singlestructure);
-        result-> subopt_energyError.push_back(energyError);
-        result-> subopt_freeEnergy.push_back(correctedEnergy);
+        result->suboptStructures.push_back(singlestructure);
+        result->suboptEnergyError.push_back(energyError);
+        result->suboptFreeEnergy.push_back(correctedEnergy);
     }
 
     clearDnaStructures(&suboptStructs);
 
     //get defect here later for now popuolate with 0
-    result -> ensembleDefect=0;
+    result->ensembleDefect=0;
 
 
     return result;
 }
+
 

--- a/lib/NUPACK/emscripten/FullEnsemble.cpp
+++ b/lib/NUPACK/emscripten/FullEnsemble.cpp
@@ -1,0 +1,71 @@
+#include "FullEnsemble.h"
+#include "EmscriptenUtils.h"
+
+#include "src/thermo/utils/pfuncUtilsConstants.h"
+#include "src/thermo/utils/pfuncUtilsHeader.h"
+#include "src/shared/utilsHeader.h"
+#include "src/thermo/utils/DNAExternals.h"
+#include <vector>
+#include <utility>
+#include <string> 
+
+
+FullAdvancedResult* FullEnsembleNoBindingSite(const std::string& seqString, int temperature, float kcal_delta_range_mfe_subopt, bool const pseudoknotted = false)
+{
+
+    auto autoSeqString = MakeCString(seqString);
+    char* string = autoSeqString.get();
+
+    int seqNum[MAXSEQLENGTH+1];
+    int tmpLength = strlen(string);
+    dnaStructures suboptStructs = {NULL, 0, 0, 0, 0};
+
+    convertSeq(string, seqNum, tmpLength);
+    //first get teh ensemble through subopt
+    if ( pseudoknotted ) {
+        mfeFullWithSym_SubOpt(seqNum, tmpLength, &suboptStructs, 5, RNA, 1 /*DANGLETYPE*/, 
+                                temperature, TRUE, (DBL_TYPE) kcal_delta_range_mfe_subopt, 
+                                0, SODIUM_CONC, MAGNESIUM_CONC, USE_LONG_HELIX_FOR_SALT_CORRECTION);
+    } else {
+        mfeFullWithSym_SubOpt(seqNum, tmpLength, &suboptStructs, 3, RNA, 1 /*DANGLETYPE*/, 
+                                temperature, TRUE, (DBL_TYPE) kcal_delta_range_mfe_subopt, 
+                                0, SODIUM_CONC, MAGNESIUM_CONC, USE_LONG_HELIX_FOR_SALT_CORRECTION);
+    }
+
+    //initialize the result to return
+    FullAdvancedResult* result = new FullAdvancedResult();
+    
+    
+    //get dot bracket notation from data 
+    for(int i = 0; i < suboptStructs.nStructs; i++) {
+        //each structure reset this
+        std::string singlestructure = "";             
+        for(int j = 0; j < suboptStructs.seqlength; j++) {
+            if(suboptStructs.validStructs[i].theStruct[j] > j) {
+                singlestructure.push_back('(');
+            }
+            else if(suboptStructs.validStructs[i].theStruct[j] == -1 ) {
+                singlestructure.push_back('.');
+            }
+            else singlestructure.push_back(')');
+        }  
+        //get energies
+        std::string energyError = std::to_string(suboptStructs.validStructs[i].error);
+        std::string correctedEnergy = std::to_string(suboptStructs.validStructs[i].correctedEnergy);  
+        
+
+        //write out data
+        result-> subopt_structures.push_back(singlestructure);
+        result-> subopt_energyError.push_back(energyError);
+        result-> subopt_freeEnergy.push_back(correctedEnergy);
+    }
+
+    clearDnaStructures(&suboptStructs);
+
+    //get defect here later for now popuolate with 0
+    result -> ensembleDefect=0;
+
+
+    return result;
+}
+

--- a/lib/NUPACK/emscripten/FullEnsemble.h
+++ b/lib/NUPACK/emscripten/FullEnsemble.h
@@ -7,11 +7,12 @@
 
 struct FullAdvancedResult {
     double ensembleDefect;
-    std::vector<std::string> subopt_structures;
-    std::vector<std::string> subopt_energyError;
-    std::vector<std::string> subopt_freeEnergy;
+    std::vector<std::string> suboptStructures;
+    std::vector<double> suboptEnergyError;
+    std::vector<double> suboptFreeEnergy;
 };
 
-FullAdvancedResult* FullEnsembleNoBindingSite (const std::string& seqString, int temperature, float kcal_delta_range_mfe_subopt, bool const pseudoknotted);
+FullAdvancedResult* FullEnsembleNoBindingSite (const std::string& seqString, int temperature, float kcalDeltaRange, bool const pseudoknotted);
+FullAdvancedResult* FullEnsembleWithOligos (const std::string& seqString, int temperature, float kcalDeltaRange,  bool const pseudoknotted);
 
 #endif //NUPACK_FULLENSEMBLE_H

--- a/lib/NUPACK/emscripten/FullEnsemble.h
+++ b/lib/NUPACK/emscripten/FullEnsemble.h
@@ -1,0 +1,17 @@
+#ifndef NUPACK_FULLENSEMBLE_H
+#define NUPACK_FULLENSEMBLE_H
+
+#include <string>
+#include <vector>
+
+
+struct FullAdvancedResult {
+    double ensembleDefect;
+    std::vector<std::string> subopt_structures;
+    std::vector<std::string> subopt_energyError;
+    std::vector<std::string> subopt_freeEnergy;
+};
+
+FullAdvancedResult* FullEnsembleNoBindingSite (const std::string& seqString, int temperature, float kcal_delta_range_mfe_subopt, bool const pseudoknotted);
+
+#endif //NUPACK_FULLENSEMBLE_H

--- a/lib/contrafold/.gitignore
+++ b/lib/contrafold/.gitignore
@@ -4,3 +4,4 @@ Makefile
 cmake_install.cmake
 dist
 ./contrafold
+contrafold_*.tar.gz

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "webpack-merge": "^5.7.3"
       },
       "optionalDependencies": {
-        "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#06199966f2bf2b0e3756986751a4e53f36a3cef6"
+        "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#644a2bc9f9a3b262583b1dd8fe769d750873b25f"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6943,9 +6943,8 @@
       "license": "ISC"
     },
     "node_modules/eternajs-folding-engines": {
-      "version": "1.6.0",
-      "resolved": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#06199966f2bf2b0e3756986751a4e53f36a3cef6",
-      "integrity": "sha512-KFXPC14QBLSp7tEwi5dn6bTavdYB5rJ9w8eVxJ09gNWFDKDy/YMbpX+uBchlgiQq9x6Id9YmHCWngZlDuuI4XA==",
+      "version": "1.7.0",
+      "resolved": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#644a2bc9f9a3b262583b1dd8fe769d750873b25f",
       "optional": true
     },
     "node_modules/eventemitter3": {
@@ -19834,9 +19833,8 @@
       "integrity": "sha512-HA14xShtJw9yAv4akHkbIVjXmy/mHPHGmnE9/Y1iE4cxJ+PqVobNxMR97IjLdFopHXcsaEPnYwp/Qgo/HPbMeg=="
     },
     "eternajs-folding-engines": {
-      "version": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#06199966f2bf2b0e3756986751a4e53f36a3cef6",
-      "integrity": "sha512-KFXPC14QBLSp7tEwi5dn6bTavdYB5rJ9w8eVxJ09gNWFDKDy/YMbpX+uBchlgiQq9x6Id9YmHCWngZlDuuI4XA==",
-      "from": "eternajs-folding-engines@github:eternagame/eternajs-folding-engines#06199966f2bf2b0e3756986751a4e53f36a3cef6",
+      "version": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#644a2bc9f9a3b262583b1dd8fe769d750873b25f",
+      "from": "eternajs-folding-engines@github:eternagame/eternajs-folding-engines#644a2bc9f9a3b262583b1dd8fe769d750873b25f",
       "optional": true
     },
     "eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
     ]
   },
   "optionalDependencies": {
-    "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#06199966f2bf2b0e3756986751a4e53f36a3cef6"
+    "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#644a2bc9f9a3b262583b1dd8fe769d750873b25f"
   }
 }

--- a/src/eterna/folding/Folder.ts
+++ b/src/eterna/folding/Folder.ts
@@ -4,8 +4,8 @@ import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 
-export type CacheItem = SecStruct | number[] | FullEvalCache | MultiFoldResult | undefined;
-export type CacheKey = Record<string, string | number | number[] | boolean | Oligo[] | null>;
+export type CacheItem = SecStruct | number[] | FullEvalCache | MultiFoldResult | SuboptEnsembleResult | undefined;
+export type CacheKey = Record<string, string | string[] | number | number[] | boolean | Oligo[] | null>;
 
 export interface MultiFoldResult {
     pairs: SecStruct;
@@ -17,6 +17,14 @@ export interface FullEvalCache {
     nodes: number[];
     energy: number;
 }
+
+export interface SuboptEnsembleResult {
+    ensembleDefect: number;
+    suboptStructures: string[];
+    suboptEnergyError: number[];
+    suboptFreeEnergy: number[];
+}
+
 
 export default abstract class Folder {
     public abstract get name (): string;
@@ -86,10 +94,16 @@ export default abstract class Folder {
         return false;
     }
 
-    public getSuboptEnsemble(
-        _seq: Sequence, _temp: number, _kcal_delta_range_mfe_subopt: number, _pseudoknotted: boolean = false
-    ): string[][] {
-        return new Array<Array<string>>();
+    public getSuboptEnsembleNoBindingSite(
+        _seq: Sequence, _kcalDeltaRange: number, _pseudoknotted: boolean = false, _temp: number = 37
+    ): SuboptEnsembleResult {
+        return  {ensembleDefect: 0, suboptStructures: [], suboptEnergyError: [], suboptFreeEnergy:[]};
+    }
+
+    public getSuboptEnsembleWithOligos(
+        _seq: Sequence, _oligos: string[], _kcalDeltaRange: number, _pseudoknotted: boolean = false, _temp: number = 37
+    ): SuboptEnsembleResult {
+        return  {ensembleDefect: 0, suboptStructures: [], suboptEnergyError: [], suboptFreeEnergy:[]};
     }
 
     public getDotPlot(

--- a/src/eterna/folding/Folder.ts
+++ b/src/eterna/folding/Folder.ts
@@ -86,6 +86,12 @@ export default abstract class Folder {
         return false;
     }
 
+    public getSuboptEnsemble(
+        _seq: Sequence, _temp: number, _kcal_delta_range_mfe_subopt: number, _pseudoknotted: boolean = false
+    ): string[][] {
+        return new Array<Array<string>>();
+    }
+
     public getDotPlot(
         _seq: Sequence, _secstruct: SecStruct, _temp: number = 37, _pseudoknots: boolean = false
     ): DotPlot | null {

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -9,7 +9,9 @@ import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 /* eslint-disable import/no-duplicates, import/no-unresolved */
 import * as NupackLib from './engines/NupackLib';
-import {DotPlotResult, FullEvalResult, FullFoldResult} from './engines/NupackLib';
+import {
+    DotPlotResult, FullEvalResult, FullFoldResult, FullAdvancedResult
+} from './engines/NupackLib';
 /* eslint-enable import/no-duplicates, import/no-unresolved */
 import Folder, {MultiFoldResult, CacheKey, FullEvalCache} from './Folder';
 import FoldUtil from './FoldUtil';
@@ -83,6 +85,37 @@ export default class NuPACK extends Folder {
     /* override */
     public get name(): string {
         return NuPACK.NAME;
+    }
+
+    /* override */
+    public getSuboptEnsemble(seq: Sequence, temp: number, kcal_delta: number,
+        pseudoknotted: boolean = false): string[][] {
+        let result: FullAdvancedResult | null = null;
+        result = this._lib
+            .FullEnsembleNoBindingSite(
+                seq.sequenceString(), temp,
+                kcal_delta, pseudoknotted
+            );
+        if (!result) {
+            throw new Error('NuPACK returned a null result');
+        }
+        const suboptdata: string[][] = new Array<Array<string>>();
+        const subopt_structures_array = EmscriptenUtil.stdVectorToArray(result.subopt_structures);
+        const subopt_energyError_array = EmscriptenUtil.stdVectorToArray(result.subopt_energyError);
+        const subopt_freeEnergy_array = EmscriptenUtil.stdVectorToArray(result.subopt_freeEnergy);
+
+        suboptdata.push(subopt_structures_array);
+        suboptdata.push(subopt_energyError_array);
+        suboptdata.push(subopt_freeEnergy_array);
+
+        // let ensmeble_structures: string[] = [];
+        //
+        // for (int index = 0; index  < ArraySuboptdata.length; index ++) {
+        // let struct = SecStruct.fromParens(ArraySuboptdata[index].toString());
+        // ensmeble_structures.push(struct);
+        // }
+
+        return suboptdata;
     }
 
     /* override */

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -89,13 +89,13 @@ export default class NuPACK extends Folder {
 
 
     /* override */
-    public getSuboptEnsembleWithOligos(seq: Sequence, oligoStrings: string[], kcal_delta: number, 
+    public getSuboptEnsembleWithOligos(seq: Sequence, oligoStrings: string[], kcalDeltaRange: number, 
         pseudoknotted: boolean = false, temp: number  = 37
-        ): SuboptEnsembleResult {
+    ): SuboptEnsembleResult {
         const key = {
             primitive: 'subopt',
             seq: seq.baseArray,
-            kcal_delta,
+            kcalDeltaRange,
             pseudoknotted, 
             temp
         };
@@ -129,7 +129,7 @@ export default class NuPACK extends Folder {
         let result: FullAdvancedResult | null = null;
         result = this._lib.FullEnsembleWithOligos(
             seqArr.sequenceString(), temp, 
-            kcal_delta, pseudoknotted 
+            kcalDeltaRange, pseudoknotted 
             );
             
         if (!result) {
@@ -143,8 +143,8 @@ export default class NuPACK extends Folder {
         const subopt_structures_energyErrors: number[] = EmscriptenUtil.stdVectorToArray(result.suboptEnergyError);
         suboptdataCache.suboptEnergyError = subopt_structures_energyErrors;
         
-        const subopt_structures_freeEnergy: number[] = EmscriptenUtil.stdVectorToArray(result.suboptFreeEnergy);
-        suboptdataCache.suboptFreeEnergy = subopt_structures_freeEnergy;
+        const suboptStructuresFreeEnergy: number[] = EmscriptenUtil.stdVectorToArray(result.suboptFreeEnergy);
+        suboptdataCache.suboptFreeEnergy = suboptStructuresFreeEnergy;
             
 
         this.putCache(key, suboptdataCache);
@@ -153,13 +153,13 @@ export default class NuPACK extends Folder {
 
 
     /* override */
-    public getSuboptEnsembleNoBindingSite(seq: Sequence, kcal_delta: number, 
+    public getSuboptEnsembleNoBindingSite(seq: Sequence, kcalDeltaRange: number, 
         pseudoknotted: boolean = false, temp: number  = 37
-        ): SuboptEnsembleResult {
+    ): SuboptEnsembleResult {
         const key = {
             primitive: 'subopt',
             seq: seq.baseArray,
-            kcal_delta,
+            kcalDeltaRange,
             pseudoknotted,            
             //bindingSite,
             //bonus,                
@@ -183,7 +183,7 @@ export default class NuPACK extends Folder {
         let result: FullAdvancedResult | null = null;
         result = this._lib.FullEnsembleNoBindingSite(
             seq.sequenceString(), temp, 
-            kcal_delta, pseudoknotted 
+            kcalDeltaRange, pseudoknotted 
             );
             
         if (!result) {
@@ -198,8 +198,8 @@ export default class NuPACK extends Folder {
         const subopt_structures_energyErrors: number[] = EmscriptenUtil.stdVectorToArray(result.suboptEnergyError);
         suboptdataCache.suboptEnergyError = subopt_structures_energyErrors;
         
-        const subopt_structures_freeEnergy: number[] = EmscriptenUtil.stdVectorToArray(result.suboptFreeEnergy);
-        suboptdataCache.suboptFreeEnergy = subopt_structures_freeEnergy;
+        const suboptStructuresFreeEnergy: number[] = EmscriptenUtil.stdVectorToArray(result.suboptFreeEnergy);
+        suboptdataCache.suboptFreeEnergy = suboptStructuresFreeEnergy;
                
 
         this.putCache(key, suboptdataCache);

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -13,7 +13,9 @@ import {
     DotPlotResult, FullEvalResult, FullFoldResult, FullAdvancedResult
 } from './engines/NupackLib';
 /* eslint-enable import/no-duplicates, import/no-unresolved */
-import Folder, {MultiFoldResult, CacheKey, FullEvalCache, SuboptEnsembleResult} from './Folder';
+import Folder, {
+    MultiFoldResult, CacheKey, FullEvalCache, SuboptEnsembleResult
+} from './Folder';
 import FoldUtil from './FoldUtil';
 
 export default class NuPACK extends Folder {
@@ -87,16 +89,14 @@ export default class NuPACK extends Folder {
         return NuPACK.NAME;
     }
 
-
     /* override */
-    public getSuboptEnsembleWithOligos(seq: Sequence, oligoStrings: string[], kcalDeltaRange: number, 
-        pseudoknotted: boolean = false, temp: number  = 37
-    ): SuboptEnsembleResult {
+    public getSuboptEnsembleWithOligos(seq: Sequence, oligoStrings: string[], kcalDeltaRange: number,
+        pseudoknotted: boolean = false, temp: number = 37): SuboptEnsembleResult {
         const key = {
             primitive: 'subopt',
             seq: seq.baseArray,
             kcalDeltaRange,
-            pseudoknotted, 
+            pseudoknotted,
             temp
         };
 
@@ -104,65 +104,61 @@ export default class NuPACK extends Folder {
         if (suboptdataCache != null) {
             // trace("getSuboptEnsemble cache hit");
             return suboptdataCache;
-        }        
+        }
 
-    
-        //initialize empty result cache
+        // initialize empty result cache
         suboptdataCache = {
             ensembleDefect: 0,
             suboptStructures: [],
             suboptEnergyError: [],
-            suboptFreeEnergy:[]
+            suboptFreeEnergy: []
         };
 
         let newSequence: string = seq.sequenceString();
-        for (let oligoIndex=0; oligoIndex < oligoStrings.length; oligoIndex++) {
-            let oligoSequence: string = oligoStrings[oligoIndex];               
-            newSequence = newSequence + "&" + oligoSequence;                      
+        for (let oligoIndex = 0; oligoIndex < oligoStrings.length; oligoIndex++) {
+            const oligoSequence: string = oligoStrings[oligoIndex];
+            newSequence = `${newSequence}&${oligoSequence}`;
         }
 
-        //now get subopt stuff
-        const seqArr: Sequence = Sequence.fromSequenceString(newSequence);   
+        // now get subopt stuff
+        const seqArr: Sequence = Sequence.fromSequenceString(newSequence);
 
-        //run nupack code
-        //pass a new sequence strucure as teh strucuture based on the concatinated oligo string
+        // run nupack code
+        // pass a new sequence strucure as teh strucuture based on the concatinated oligo string
         let result: FullAdvancedResult | null = null;
         result = this._lib.FullEnsembleWithOligos(
-            seqArr.sequenceString(), temp, 
-            kcalDeltaRange, pseudoknotted 
-            );
-            
+            seqArr.sequenceString(), temp,
+            kcalDeltaRange, pseudoknotted
+        );
+
         if (!result) {
             throw new Error('NuPACK returned a null result');
         }
-        
-        //prepare teh results for return and storage in cache
-        const subopt_structures: string[] = EmscriptenUtil.stdVectorToArray(result.suboptStructures);
-        suboptdataCache.suboptStructures = subopt_structures;
-        
-        const subopt_structures_energyErrors: number[] = EmscriptenUtil.stdVectorToArray(result.suboptEnergyError);
-        suboptdataCache.suboptEnergyError = subopt_structures_energyErrors;
-        
+
+        // prepare teh results for return and storage in cache
+        const suboptStructures: string[] = EmscriptenUtil.stdVectorToArray(result.suboptStructures);
+        suboptdataCache.suboptStructures = suboptStructures;
+
+        const suboptStructuresEnergyErrors: number[] = EmscriptenUtil.stdVectorToArray(result.suboptEnergyError);
+        suboptdataCache.suboptEnergyError = suboptStructuresEnergyErrors;
+
         const suboptStructuresFreeEnergy: number[] = EmscriptenUtil.stdVectorToArray(result.suboptFreeEnergy);
         suboptdataCache.suboptFreeEnergy = suboptStructuresFreeEnergy;
-            
 
         this.putCache(key, suboptdataCache);
         return suboptdataCache;
     }
 
-
     /* override */
-    public getSuboptEnsembleNoBindingSite(seq: Sequence, kcalDeltaRange: number, 
-        pseudoknotted: boolean = false, temp: number  = 37
-    ): SuboptEnsembleResult {
+    public getSuboptEnsembleNoBindingSite(seq: Sequence, kcalDeltaRange: number,
+        pseudoknotted: boolean = false, temp: number = 37): SuboptEnsembleResult {
         const key = {
             primitive: 'subopt',
             seq: seq.baseArray,
             kcalDeltaRange,
-            pseudoknotted,            
-            //bindingSite,
-            //bonus,                
+            pseudoknotted,
+            // bindingSite,
+            // bonus,
             temp
         };
 
@@ -170,37 +166,35 @@ export default class NuPACK extends Folder {
         if (suboptdataCache != null) {
             // trace("getSuboptEnsemble cache hit");
             return suboptdataCache;
-        }         
-            
-        //initialize empty result cache
+        }
+
+        // initialize empty result cache
         suboptdataCache = {
             ensembleDefect: 0,
             suboptStructures: [],
             suboptEnergyError: [],
-            suboptFreeEnergy:[]
+            suboptFreeEnergy: []
         };
 
         let result: FullAdvancedResult | null = null;
         result = this._lib.FullEnsembleNoBindingSite(
-            seq.sequenceString(), temp, 
-            kcalDeltaRange, pseudoknotted 
-            );
-            
+            seq.sequenceString(), temp,
+            kcalDeltaRange, pseudoknotted
+        );
+
         if (!result) {
             throw new Error('NuPACK returned a null result');
         }
 
-        
-        //prepare teh results for return and storage in cache
-        const subopt_structures: string[] = EmscriptenUtil.stdVectorToArray(result.suboptStructures);
-        suboptdataCache.suboptStructures = subopt_structures;
+        // prepare teh results for return and storage in cache
+        const suboptStructures: string[] = EmscriptenUtil.stdVectorToArray(result.suboptStructures);
+        suboptdataCache.suboptStructures = suboptStructures;
 
-        const subopt_structures_energyErrors: number[] = EmscriptenUtil.stdVectorToArray(result.suboptEnergyError);
-        suboptdataCache.suboptEnergyError = subopt_structures_energyErrors;
-        
+        const suboptStructuresEnergyErrors: number[] = EmscriptenUtil.stdVectorToArray(result.suboptEnergyError);
+        suboptdataCache.suboptEnergyError = suboptStructuresEnergyErrors;
+
         const suboptStructuresFreeEnergy: number[] = EmscriptenUtil.stdVectorToArray(result.suboptFreeEnergy);
         suboptdataCache.suboptFreeEnergy = suboptStructuresFreeEnergy;
-               
 
         this.putCache(key, suboptdataCache);
         return suboptdataCache;
@@ -564,10 +558,10 @@ export default class NuPACK extends Folder {
             order.push(ii);
         }
 
-        //this code appears to do do peform multiple runs where it 
-        //incrementally adds a oligo to the cofold if needed and scores it.
-        //it finds best fit and then uses that. I needed to figure out what was happeing
-        //here for subopt stuff and wanted to commment -Jennifer Pearl
+        // this code appears to do do peform multiple runs where it
+        // incrementally adds a oligo to the cofold if needed and scores it.
+        // it finds best fit and then uses that. I needed to figure out what was happeing
+        // here for subopt stuff and wanted to commment -Jennifer Pearl
         let more: boolean;
         do {
             for (let ii = numOligo; ii >= 0; ii--) {

--- a/src/eterna/folding/__tests__/Folder.test.ts
+++ b/src/eterna/folding/__tests__/Folder.test.ts
@@ -42,6 +42,32 @@ for (let folderType of [Vienna, Vienna2, NuPACK, LinearFoldV]) {
             .resolves.toBeUndefined();
     });
 
+    test('Nupack_Subopt_structures', () => {    
+   	 expect.assertions(1);
+    	 return expect(CreateFolder(NuPACK)
+           .then((folder) => {
+            if (folder === null) {
+                expect(true).toBeTruthy();
+                return;
+            }
+
+            const structures = folder.getSuboptEnsemble(
+                Sequence.fromSequenceString("auauauagaaaauauaua"),
+                37, 1, false);
+	    
+	        //let num = structures.length;
+	        console.log(structures); 
+            //console.log(structures[0]); 			 
+                
+            //expect(structures).toBeDefined();
+            //expect(structures[0])
+                //.toEqual(".((((((.....))))))");
+        }))
+        .resolves.toBeUndefined(); // (we're returning a promise)
+
+    });
+
+
     test(`${folderType.NAME}:emptyStructure`, () => {
         expect.assertions(2);
         return expect(CreateFolder(folderType)

--- a/src/eterna/folding/__tests__/Folder.test.ts
+++ b/src/eterna/folding/__tests__/Folder.test.ts
@@ -26,6 +26,106 @@ function CreateFolder(type: any): Promise<Folder | null> {
     return type.create();
 }
 
+test('NuPACK:suboptstructuresNoOligos', () => {    
+    expect.assertions(13);
+     return expect(CreateFolder(NuPACK)
+       .then((folder) => {
+        if (folder === null) {
+            expect(true).toBeTruthy();
+            return;
+        }
+        let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
+        let temperature: number = 37;
+        let isPsuedoknot:boolean = false;
+        let kcalDelta: number = 1;
+
+        const suboptEnsembleObject: 
+            SuboptEnsembleResult = folder.getSuboptEnsembleNoBindingSite (
+            sequence, kcalDelta, 
+            isPsuedoknot, temperature
+        );	   
+        
+  
+        let ensembleStructures: string[] = suboptEnsembleObject.suboptStructures;
+        let ensembleStructuresEnergyError: number[]= suboptEnsembleObject.suboptEnergyError;
+        let ensembleStructuresFreeEnergy: number[] = suboptEnsembleObject.suboptFreeEnergy;
+        
+
+        expect(ensembleStructures).toBeDefined();
+        expect(ensembleStructures[0])
+            .toEqual(".((((((.....))))))");
+        expect(ensembleStructures[1])
+            .toEqual("((((((.....)))))).");
+        expect(ensembleStructures[2])
+            .toEqual("..(((((.....))))).");
+
+        expect(ensembleStructuresEnergyError).toBeDefined();
+        expect(ensembleStructuresEnergyError[0])
+            .toEqual(0);
+        expect(ensembleStructuresEnergyError[1])
+            .toEqual(0.30000000000000027);
+        expect(ensembleStructuresEnergyError[2])
+            .toEqual(0.5000000000000002);
+
+        expect(ensembleStructuresFreeEnergy).toBeDefined();
+        expect(ensembleStructuresFreeEnergy[0])
+            .toEqual(-2.5);
+        expect(ensembleStructuresFreeEnergy[1])
+            .toEqual(-2.1999999999999997);
+        expect(ensembleStructuresFreeEnergy[2])
+            .toEqual(-1.9999999999999998);
+
+    }))
+    .resolves.toBeUndefined(); // (we're returning a promise)
+
+});
+
+test('NuPACK:suboptstructuresWithOligos', () => {    
+    expect.assertions(7);
+     return expect(CreateFolder(NuPACK)
+       .then((folder) => {
+        if (folder === null) {
+            expect(true).toBeTruthy();
+            return;
+        }
+        let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
+        let oligos: string[] = ["acgcga", "auguau"];
+        let temperature: number = 37;
+        let isPsuedoknot:boolean = false;
+        let kcalDelta: number = 1;
+
+        const suboptEnsembleObject: 
+            SuboptEnsembleResult = folder.getSuboptEnsembleWithOligos (
+            sequence, oligos, kcalDelta, 
+            isPsuedoknot, temperature
+        );	   
+        
+  
+        let ensembleStructures: string[] = suboptEnsembleObject.suboptStructures;
+        let ensembleStructuresEnergyError: number[]= suboptEnsembleObject.suboptEnergyError;
+        let ensembleStructuresFreeEnergy: number[] = suboptEnsembleObject.suboptFreeEnergy;
+       
+        
+        expect(ensembleStructures).toBeDefined();
+        expect(ensembleStructures[0])
+            .toEqual(".(((((.(..........&.)....&))))).");           
+
+        expect(ensembleStructuresEnergyError).toBeDefined();
+        expect(ensembleStructuresEnergyError[0])
+            .toEqual(0);
+       
+
+        expect(ensembleStructuresFreeEnergy).toBeDefined();
+        expect(ensembleStructuresFreeEnergy[0])
+            .toEqual(-5.462702838158919);
+      
+
+    }))
+    .resolves.toBeUndefined(); // (we're returning a promise)
+
+});
+
+
 for (let folderType of [Vienna, Vienna2, NuPACK, LinearFoldV]) {
     test(`${folderType.NAME}:snowflake`, () => {
         // expect.assertions: the async code should result in X assertions being called
@@ -43,104 +143,7 @@ for (let folderType of [Vienna, Vienna2, NuPACK, LinearFoldV]) {
             .resolves.toBeUndefined();
     });
 
-    test('Nupack_Subopt_structures_noOligos', () => {    
-   	 expect.assertions(13);
-    	 return expect(CreateFolder(NuPACK)
-           .then((folder) => {
-            if (folder === null) {
-                expect(true).toBeTruthy();
-                return;
-            }
-            let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
-            let temperature: number = 37;
-            let isPsuedoknot:boolean = false;
-            let kcalDelta: number = 1;
-
-            const suboptEnsembleObject: 
-                SuboptEnsembleResult = folder.getSuboptEnsembleNoBindingSite (
-                sequence, kcalDelta, 
-                isPsuedoknot, temperature
-            );	   
-	        
-      
-            let ensembleStructures: string[] = suboptEnsembleObject.suboptStructures;
-            let ensembleStructuresEnergyError: number[]= suboptEnsembleObject.suboptEnergyError;
-            let ensembleStructuresFreeEnergy: number[] = suboptEnsembleObject.suboptFreeEnergy;
-            
-
-            expect(ensembleStructures).toBeDefined();
-            expect(ensembleStructures[0])
-                .toEqual(".((((((.....))))))");
-            expect(ensembleStructures[1])
-                .toEqual("((((((.....)))))).");
-            expect(ensembleStructures[2])
-                .toEqual("..(((((.....))))).");
-
-            expect(ensembleStructuresEnergyError).toBeDefined();
-            expect(ensembleStructuresEnergyError[0])
-                .toEqual(0);
-            expect(ensembleStructuresEnergyError[1])
-                .toEqual(0.30000000000000027);
-            expect(ensembleStructuresEnergyError[2])
-                .toEqual(0.5000000000000002);
-
-            expect(ensembleStructuresFreeEnergy).toBeDefined();
-            expect(ensembleStructuresFreeEnergy[0])
-                .toEqual(-2.5);
-            expect(ensembleStructuresFreeEnergy[1])
-                .toEqual(-2.1999999999999997);
-            expect(ensembleStructuresFreeEnergy[2])
-                .toEqual(-1.9999999999999998);
-
-        }))
-        .resolves.toBeUndefined(); // (we're returning a promise)
-
-    });
-
-    test('Nupack_Subopt_structures_withOligos', () => {    
-   	 expect.assertions(7);
-    	 return expect(CreateFolder(NuPACK)
-           .then((folder) => {
-            if (folder === null) {
-                expect(true).toBeTruthy();
-                return;
-            }
-            let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
-            let oligos: string[] = ["acgcga", "auguau"];
-            let temperature: number = 37;
-            let isPsuedoknot:boolean = false;
-            let kcalDelta: number = 1;
-
-            const suboptEnsembleObject: 
-                SuboptEnsembleResult = folder.getSuboptEnsembleWithOligos (
-                sequence, oligos, kcalDelta, 
-                isPsuedoknot, temperature
-            );	   
-	        
-      
-            let ensembleStructures: string[] = suboptEnsembleObject.suboptStructures;
-            let ensembleStructuresEnergyError: number[]= suboptEnsembleObject.suboptEnergyError;
-            let ensembleStructuresFreeEnergy: number[] = suboptEnsembleObject.suboptFreeEnergy;
-           
-           
-            expect(ensembleStructures).toBeDefined();
-            expect(ensembleStructures[0])
-                .toEqual(".(((((.(..........&.)....&))))).");           
-
-            expect(ensembleStructuresEnergyError).toBeDefined();
-            expect(ensembleStructuresEnergyError[0])
-                .toEqual(0);
-           
-
-            expect(ensembleStructuresFreeEnergy).toBeDefined();
-            expect(ensembleStructuresFreeEnergy[0])
-                .toEqual(-5.462702838158919);
-          
-
-        }))
-        .resolves.toBeUndefined(); // (we're returning a promise)
-
-    });
+    
 
     test(`${folderType.NAME}:emptyStructure`, () => {
         expect.assertions(2);

--- a/src/eterna/folding/__tests__/Folder.test.ts
+++ b/src/eterna/folding/__tests__/Folder.test.ts
@@ -1,4 +1,4 @@
-import Folder from '../Folder';
+import Folder, {SuboptEnsembleResult} from '../Folder';
 import NuPACK from '../NuPACK';
 import Vienna from '../Vienna';
 import Vienna2 from '../Vienna2';
@@ -6,6 +6,7 @@ import LinearFoldV from '../LinearFoldV';
 import './jest-matcher-deep-close-to';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
+
 
 const SNOWFLAKE_SEQ = Sequence.fromSequenceString('GUGGACAAGAUGAAACAUCAGUAACAAGCGCAAAGCGCGGGCAAAGCCCCCGGAAACCGGAAGUUACAGAACAAAGUUCAAGUUUACAAGUGGACAAGUUGAAACAACAGUUACAAGACGAAACGUCGGCCAAAGGCCCCAUAAAAUGGAAGUAACACUUGAAACAAGAAGUUUACAAGUUGACAAGUUCAAAGAACAGUUACAAGUGGAAACCACGCGCAAAGCGCCUCCAAAGGAGAAGUAACAGAAGAAACUUCAAGUUAGCAAGUGGUCAAGUACAAAGUACAGUAACAACAUCAAAGAUGGCGCAAAGCGCGAGCAAAGCUCAAGUUACAGAACAAAGUUCAAGAUUACAAGAGUGCAAGAAGAAACUUCAGAUAGAACUGCAAAGCAGCACCAAAGGUGGGGCAAAGCCCAACUAUCAGUUGAAACAACAAGUAUUCAAGAGGUCAAGAUCAAAGAUCAGUAACAAGUGCAAAGCACGGGCAAAGCCCGACCAAAGGUCAAGUUACAGUUCAAAGAACAAGAUUUC');
 const SNOWFLAKE_STRUCT = SecStruct.fromParens('((((((..((((...)))).(((((..((((...))))((((...))))((((...))))..))))).((((...))))..))))))..((((((..((((...)))).(((((..((((...))))((((...))))((((...))))..))))).((((...))))..))))))..((((((..((((...)))).(((((..((((...))))((((...))))((((...))))..))))).((((...))))..))))))..((((((..((((...)))).(((((..((((...))))((((...))))((((...))))..))))).((((...))))..))))))..((((((..((((...)))).(((((..((((...))))((((...))))((((...))))..))))).((((...))))..))))))..((((((..((((...)))).(((((..((((...))))((((...))))((((...))))..))))).((((...))))..))))))');
@@ -42,31 +43,104 @@ for (let folderType of [Vienna, Vienna2, NuPACK, LinearFoldV]) {
             .resolves.toBeUndefined();
     });
 
-    test('Nupack_Subopt_structures', () => {    
-   	 expect.assertions(1);
+    test('Nupack_Subopt_structures_noOligos', () => {    
+   	 expect.assertions(13);
     	 return expect(CreateFolder(NuPACK)
            .then((folder) => {
             if (folder === null) {
                 expect(true).toBeTruthy();
                 return;
             }
+            let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
+            let temperature: number = 37;
+            let isPsuedoknot:boolean = false;
+            let kcalDelta: number = 1;
 
-            const structures = folder.getSuboptEnsemble(
-                Sequence.fromSequenceString("auauauagaaaauauaua"),
-                37, 1, false);
-	    
-	        //let num = structures.length;
-	        console.log(structures); 
-            //console.log(structures[0]); 			 
-                
-            //expect(structures).toBeDefined();
-            //expect(structures[0])
-                //.toEqual(".((((((.....))))))");
+            const suboptEnsembleObject: 
+                SuboptEnsembleResult = folder.getSuboptEnsembleNoBindingSite (
+                sequence, kcalDelta, 
+                isPsuedoknot, temperature
+            );	   
+	        
+      
+            let ensembleStructures: string[] = suboptEnsembleObject.suboptStructures;
+            let ensembleStructuresEnergyError: number[]= suboptEnsembleObject.suboptEnergyError;
+            let ensembleStructuresFreeEnergy: number[] = suboptEnsembleObject.suboptFreeEnergy;
+            
+
+            expect(ensembleStructures).toBeDefined();
+            expect(ensembleStructures[0])
+                .toEqual(".((((((.....))))))");
+            expect(ensembleStructures[1])
+                .toEqual("((((((.....)))))).");
+            expect(ensembleStructures[2])
+                .toEqual("..(((((.....))))).");
+
+            expect(ensembleStructuresEnergyError).toBeDefined();
+            expect(ensembleStructuresEnergyError[0])
+                .toEqual(0);
+            expect(ensembleStructuresEnergyError[1])
+                .toEqual(0.30000000000000027);
+            expect(ensembleStructuresEnergyError[2])
+                .toEqual(0.5000000000000002);
+
+            expect(ensembleStructuresFreeEnergy).toBeDefined();
+            expect(ensembleStructuresFreeEnergy[0])
+                .toEqual(-2.5);
+            expect(ensembleStructuresFreeEnergy[1])
+                .toEqual(-2.1999999999999997);
+            expect(ensembleStructuresFreeEnergy[2])
+                .toEqual(-1.9999999999999998);
+
         }))
         .resolves.toBeUndefined(); // (we're returning a promise)
 
     });
 
+    test('Nupack_Subopt_structures_withOligos', () => {    
+   	 expect.assertions(7);
+    	 return expect(CreateFolder(NuPACK)
+           .then((folder) => {
+            if (folder === null) {
+                expect(true).toBeTruthy();
+                return;
+            }
+            let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
+            let oligos: string[] = ["acgcga", "auguau"];
+            let temperature: number = 37;
+            let isPsuedoknot:boolean = false;
+            let kcalDelta: number = 1;
+
+            const suboptEnsembleObject: 
+                SuboptEnsembleResult = folder.getSuboptEnsembleWithOligos (
+                sequence, oligos, kcalDelta, 
+                isPsuedoknot, temperature
+            );	   
+	        
+      
+            let ensembleStructures: string[] = suboptEnsembleObject.suboptStructures;
+            let ensembleStructuresEnergyError: number[]= suboptEnsembleObject.suboptEnergyError;
+            let ensembleStructuresFreeEnergy: number[] = suboptEnsembleObject.suboptFreeEnergy;
+           
+           
+            expect(ensembleStructures).toBeDefined();
+            expect(ensembleStructures[0])
+                .toEqual(".(((((.(..........&.)....&))))).");           
+
+            expect(ensembleStructuresEnergyError).toBeDefined();
+            expect(ensembleStructuresEnergyError[0])
+                .toEqual(0);
+           
+
+            expect(ensembleStructuresFreeEnergy).toBeDefined();
+            expect(ensembleStructuresFreeEnergy[0])
+                .toEqual(-5.462702838158919);
+          
+
+        }))
+        .resolves.toBeUndefined(); // (we're returning a promise)
+
+    });
 
     test(`${folderType.NAME}:emptyStructure`, () => {
         expect.assertions(2);

--- a/src/eterna/folding/__tests__/Folder.test.ts
+++ b/src/eterna/folding/__tests__/Folder.test.ts
@@ -26,14 +26,11 @@ function CreateFolder(type: any): Promise<Folder | null> {
     return type.create();
 }
 
-test('NuPACK:suboptstructuresNoOligos', () => {    
-    expect.assertions(13);
+test('NuPACK:suboptstructuresNoOligos', () => {        
      return expect(CreateFolder(NuPACK)
-       .then((folder) => {
-        if (folder === null) {
-            expect(true).toBeTruthy();
-            return;
-        }
+     .then((folder) => {
+        if (folder === null) return;
+
         let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
         let temperature: number = 37;
         let isPsuedoknot:boolean = false;
@@ -80,14 +77,11 @@ test('NuPACK:suboptstructuresNoOligos', () => {
 
 });
 
-test('NuPACK:suboptstructuresWithOligos', () => {    
-    expect.assertions(7);
+test('NuPACK:suboptstructuresWithOligos', () => {        
      return expect(CreateFolder(NuPACK)
        .then((folder) => {
-        if (folder === null) {
-            expect(true).toBeTruthy();
-            return;
-        }
+        if (folder === null) return;
+        
         let sequence = Sequence.fromSequenceString("auauauagaaaauauaua")
         let oligos: string[] = ["acgcga", "auguau"];
         let temperature: number = 37;

--- a/src/eterna/folding/engines/NupackLib/index.d.ts
+++ b/src/eterna/folding/engines/NupackLib/index.d.ts
@@ -32,6 +32,7 @@ declare class NupackLib {
     FullFoldWithBindingSite(seqString: string, switch_bp_i: number, switch_bp_p: number, switch_bp_j: number, switch_bp_q: number, switch_bp_bonus: number): NupackLib.FullFoldResult | null;
     CoFoldSequence(seqString: string): NupackLib.FullFoldResult | null;
     CoFoldSequenceWithBindingSite(seqString: string, switch_bp_i: number, switch_bp_p: number, switch_bp_j: number, switch_bp_q: number, switch_bp_bonus: number): NupackLib.FullFoldResult | null;
+    FullEnsembleNoBindingSite(seqString: string, temperature: number, kcal_delta_range_mfe_subopt: number, pseudoknotted: boolean):  NupackLib.FullAdvancedResult | null;
 }
 
 /*~ If you want to expose types from your module as well, you can
@@ -56,6 +57,14 @@ declare namespace NupackLib {
         energy: number;
         plot: stdcpp.vector<number>;
 
+        delete (): void;
+    }
+
+    export interface FullAdvancedResult {
+        ensembleDefect: number;       
+        subopt_structures: stdcpp.vector<string>;
+        subopt_energyError: stdcpp.vector<string>;
+        subopt_freeEnergy: stdcpp.vector<string>;
         delete (): void;
     }
 }

--- a/src/eterna/folding/engines/NupackLib/index.d.ts
+++ b/src/eterna/folding/engines/NupackLib/index.d.ts
@@ -32,7 +32,8 @@ declare class NupackLib {
     FullFoldWithBindingSite(seqString: string, switch_bp_i: number, switch_bp_p: number, switch_bp_j: number, switch_bp_q: number, switch_bp_bonus: number): NupackLib.FullFoldResult | null;
     CoFoldSequence(seqString: string): NupackLib.FullFoldResult | null;
     CoFoldSequenceWithBindingSite(seqString: string, switch_bp_i: number, switch_bp_p: number, switch_bp_j: number, switch_bp_q: number, switch_bp_bonus: number): NupackLib.FullFoldResult | null;
-    FullEnsembleNoBindingSite(seqString: string, temperature: number, kcal_delta_range_mfe_subopt: number, pseudoknotted: boolean):  NupackLib.FullAdvancedResult | null;
+    FullEnsembleNoBindingSite(seqString: string, temperature: number, kcalDeltaRange: number, pseudoknotted: boolean):  NupackLib.FullAdvancedResult | null;
+    FullEnsembleWithOligos (seqString: string, temperature: number, kcalDeltaRange: number, pseudoknotted: boolean):  NupackLib.FullAdvancedResult | null;
 }
 
 /*~ If you want to expose types from your module as well, you can
@@ -62,9 +63,9 @@ declare namespace NupackLib {
 
     export interface FullAdvancedResult {
         ensembleDefect: number;       
-        subopt_structures: stdcpp.vector<string>;
-        subopt_energyError: stdcpp.vector<string>;
-        subopt_freeEnergy: stdcpp.vector<string>;
+        suboptStructures: stdcpp.vector<string>;
+        suboptEnergyError: stdcpp.vector<number>;
+        suboptFreeEnergy: stdcpp.vector<number>;
         delete (): void;
     }
 }

--- a/src/eterna/layout/RNApuzzler.ts
+++ b/src/eterna/layout/RNApuzzler.ts
@@ -14,7 +14,7 @@ export default class RNApuzzler extends LayoutEngine {
      * @description AMW TODO cannot annotate type of module/program; both are any.
      */
     public static create(): Promise<RNApuzzler> {
-        // eslint-disable-next-line import/no-extraneous-dependencies
+        // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
         return import('engines-bin/rnapuzzler')
             .then((module) => EmscriptenUtil.loadProgram(module))
             .then((program) => new RNApuzzler(program));

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1313,23 +1313,41 @@ export default class PoseEditMode extends GameMode {
                 return pp.data;
             });
 
-        this._scriptInterface.addCallback('subopt',
-            (seq: string, temp: number, kcal_delta: number,
-                pseudoknotted: boolean): string[][] | null => {
+        //I want players to be able to play aroudn with temp for folding
+        this._scriptInterface.addCallback('suboptSingleSequence',
+            (seq: string, kcal_delta: number, pseudoknotted: boolean, 
+                        temp: number = 37): string[][] | null => {
                 if (this._folder === null) {
                     return null;
                 }
+                //now get subopt stuff
                 const seqArr: Sequence = Sequence.fromSequenceString(seq);
-                let folded: string[][] = new Array<Array<string>>();
-                folded = this._folder.getSuboptEnsemble(
-                    seqArr, temp, kcal_delta, pseudoknotted
-                );
-                if (folded === null) {
-                    return null;
-                }
-
-                return folded;
+                return this._folder.getSuboptEnsemble(seqArr, 
+                                    kcal_delta, pseudoknotted, temp);
+                
             });
+
+        //I want players to be able to play aroudn with temp for folding
+        this._scriptInterface.addCallback('suboptOligos',
+        (seq: string, oligoStrings: string[], kcal_delta: number, pseudoknotted: boolean, 
+                    temp: number = 37): string[][] | null => {
+            if (this._folder === null) {
+                return null;
+            }
+            //make teh sequence string from the oligos
+            let newSequence: string = seq;
+            for (let oligoIndex=0; oligoIndex < oligoStrings.length; oligoIndex++) {
+                let oligoSequence: string = oligoStrings[oligoIndex];               
+                newSequence = newSequence + "&" + oligoSequence;
+                          
+            }
+
+            //now get subopt stuff
+            const seqArr: Sequence = Sequence.fromSequenceString(newSequence);      
+            return this._folder.getSuboptEnsembleWithOligos(seqArr, 
+                            kcal_delta, pseudoknotted, temp);
+            
+        });
 
         this._scriptInterface.addCallback('cofold',
             (seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null): string | null => {

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1315,22 +1315,24 @@ export default class PoseEditMode extends GameMode {
 
         //I want players to be able to play aroudn with temp for folding
         this._scriptInterface.addCallback('suboptSingleSequence',
-            (seq: string, kcal_delta: number, pseudoknotted: boolean, 
-                        temp: number = 37): string[][] | null => {
+            (seq: string, kcalDelta: number,  
+                pseudoknotted: boolean,temp: number = 37
+            ): string[][] | null => {
                 if (this._folder === null) {
                     return null;
                 }
                 //now get subopt stuff
                 const seqArr: Sequence = Sequence.fromSequenceString(seq);
                 return this._folder.getSuboptEnsemble(seqArr, 
-                                    kcal_delta, pseudoknotted, temp);
+                    kcalDelta, pseudoknotted, temp);
                 
             });
 
         //I want players to be able to play aroudn with temp for folding
         this._scriptInterface.addCallback('suboptOligos',
-        (seq: string, oligoStrings: string[], kcal_delta: number, pseudoknotted: boolean, 
-                    temp: number = 37): string[][] | null => {
+        (seq: string, oligoStrings: string[], kcalDelta: number,  
+            pseudoknotted: boolean,temp: number = 37
+        ): string[][] | null => {
             if (this._folder === null) {
                 return null;
             }
@@ -1345,7 +1347,7 @@ export default class PoseEditMode extends GameMode {
             //now get subopt stuff
             const seqArr: Sequence = Sequence.fromSequenceString(newSequence);      
             return this._folder.getSuboptEnsembleWithOligos(seqArr, 
-                            kcal_delta, pseudoknotted, temp);
+                kcalDelta, pseudoknotted, temp);
             
         });
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1313,6 +1313,24 @@ export default class PoseEditMode extends GameMode {
                 return pp.data;
             });
 
+        this._scriptInterface.addCallback('subopt',
+            (seq: string, temp: number, kcal_delta: number,
+                pseudoknotted: boolean): string[][] | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                const seqArr: Sequence = Sequence.fromSequenceString(seq);
+                let folded: string[][] = new Array<Array<string>>();
+                folded = this._folder.getSuboptEnsemble(
+                    seqArr, temp, kcal_delta, pseudoknotted
+                );
+                if (folded === null) {
+                    return null;
+                }
+
+                return folded;
+            });
+
         this._scriptInterface.addCallback('cofold',
             (seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null): string | null => {
                 if (this._folder === null) {

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -24,7 +24,7 @@ import {
 import Fonts from 'eterna/util/Fonts';
 import EternaViewOptionsDialog, {EternaViewOptionsMode} from 'eterna/ui/EternaViewOptionsDialog';
 import FolderManager from 'eterna/folding/FolderManager';
-import Folder, {MultiFoldResult, CacheKey} from 'eterna/folding/Folder';
+import Folder, {MultiFoldResult, CacheKey, SuboptEnsembleResult} from 'eterna/folding/Folder';
 import {PaletteTargetType, GetPaletteTargetBaseType} from 'eterna/ui/NucleotidePalette';
 import PoseField from 'eterna/pose2D/PoseField';
 import Pose2D, {Layout, SCRIPT_MARKER_LAYER} from 'eterna/pose2D/Pose2D';
@@ -1313,43 +1313,38 @@ export default class PoseEditMode extends GameMode {
                 return pp.data;
             });
 
-        //I want players to be able to play aroudn with temp for folding
+        // I want players to be able to play aroudn with temp for folding
         this._scriptInterface.addCallback('suboptSingleSequence',
-            (seq: string, kcalDelta: number,  
-                pseudoknotted: boolean,temp: number = 37
-            ): string[][] | null => {
+            (seq: string, kcalDelta: number,
+                pseudoknotted: boolean, temp: number = 37): SuboptEnsembleResult | null => {
                 if (this._folder === null) {
                     return null;
                 }
-                //now get subopt stuff
+                // now get subopt stuff
                 const seqArr: Sequence = Sequence.fromSequenceString(seq);
-                return this._folder.getSuboptEnsemble(seqArr, 
+                return this._folder.getSuboptEnsembleNoBindingSite(seqArr,
                     kcalDelta, pseudoknotted, temp);
-                
             });
 
-        //I want players to be able to play aroudn with temp for folding
+        // I want players to be able to play aroudn with temp for folding
         this._scriptInterface.addCallback('suboptOligos',
-        (seq: string, oligoStrings: string[], kcalDelta: number,  
-            pseudoknotted: boolean,temp: number = 37
-        ): string[][] | null => {
-            if (this._folder === null) {
-                return null;
-            }
-            //make teh sequence string from the oligos
-            let newSequence: string = seq;
-            for (let oligoIndex=0; oligoIndex < oligoStrings.length; oligoIndex++) {
-                let oligoSequence: string = oligoStrings[oligoIndex];               
-                newSequence = newSequence + "&" + oligoSequence;
-                          
-            }
+            (seq: string, oligoStrings: string[], kcalDelta: number,
+                pseudoknotted: boolean, temp: number = 37): SuboptEnsembleResult | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                // make teh sequence string from the oligos
+                let newSequence: string = seq;
+                for (let oligoIndex = 0; oligoIndex < oligoStrings.length; oligoIndex++) {
+                    const oligoSequence: string = oligoStrings[oligoIndex];
+                    newSequence = `${newSequence}&${oligoSequence}`;
+                }
 
-            //now get subopt stuff
-            const seqArr: Sequence = Sequence.fromSequenceString(newSequence);      
-            return this._folder.getSuboptEnsembleWithOligos(seqArr, 
-                kcalDelta, pseudoknotted, temp);
-            
-        });
+                // now get subopt stuff
+                const seqArr: Sequence = Sequence.fromSequenceString(newSequence);
+                return this._folder.getSuboptEnsembleWithOligos(seqArr,
+                    oligoStrings, kcalDelta, pseudoknotted, temp);
+            });
 
         this._scriptInterface.addCallback('cofold',
             (seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null): string | null => {


### PR DESCRIPTION
I modified  binding.cpp, fodler.test.ts, fodler.ts, index.d.ts,Nupakc.ts, PosEditMode.ts and RNApuzzler.ts I added the c++ files FullEnsemble.cpp and .h 

This change adds only the ability to run subopt module and get secondary structures from the ensemble at each predicted energy delta and free energy. It returns the data as a sting[][] with each index being an array of strings. The first is the structures, the seconds is the error, adn the 3rd is the free energy's each index of the arrays if for the same structure.