### PR TITLE
Fix energy computation bugs in multistrand puzzles

### DIFF
--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -267,7 +267,7 @@ export default class NuPACK extends Folder {
             }
         } while (0);
 
-        let cut: number = seq.lastCut();
+        const cut: number = seq.lastCut();
         if (cut >= 0) {
             if (cache.nodes[0] !== -2 || cache.nodes.length === 2 || (cache.nodes[0] === -2 && cache.nodes[2] !== -1)) {
                 // we just scored a duplex that wasn't one, so we have to redo it properly
@@ -278,11 +278,6 @@ export default class NuPACK extends Folder {
 
                 const seqB: Sequence = seq.slice(cut + 1);
                 const pairsB: SecStruct = pairs.slice(cut + 1);
-                for (let ii = 0; ii < pairsB.length; ii++) {
-                    if (pairsB.isPaired(ii)) {
-                        pairsB.pairs[ii] -= (cut + 1);
-                    }
-                }
                 const nodesB: number[] = [];
                 const retB: number = this.scoreStructures(seqB, pairsB, pseudoknots, temp, nodesB);
 
@@ -306,12 +301,11 @@ export default class NuPACK extends Folder {
 
                 cache.energy = (retA + retB) / 100;
             } else {
-                cut = 0;
-                for (let ii = 0; ii < cache.nodes.length; ii += 2) {
-                    if (seq.baseArray[ii / 2] === RNABase.CUT) {
-                        cut++;
-                    } else {
-                        cache.nodes[ii] += cut;
+                for (let ii = 0; ii < seq.length; ii++) {
+                    if (seq.nt(ii) === RNABase.CUT) {
+                        for (let jj = 0; jj < cache.nodes.length; jj += 2) {
+                            if (cache.nodes[jj] >= ii) cache.nodes[jj]++;
+                        }
                     }
                 }
             }

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -271,6 +271,14 @@ export default class NuPACK extends Folder {
         if (cut >= 0) {
             if (cache.nodes[0] !== -2 || cache.nodes.length === 2 || (cache.nodes[0] === -2 && cache.nodes[2] !== -1)) {
                 // we just scored a duplex that wasn't one, so we have to redo it properly
+                // EG: If we have a target mode where we have two disconnected strands, we need to
+                // fold the two strands independently
+                // cache.nodes[0] is the index of the first score node, and the magic value -2 refers to
+                // the special term for the multistrand penalty
+                // FIXME: What if we have three strands where the first two are connected but the
+                // third is not? Wouldn't this score all three separately when it should score
+                // the first two together then the third separately?
+
                 const seqA: Sequence = seq.slice(0, cut);
                 const pairsA: SecStruct = pairs.slice(0, cut);
                 const nodesA: number[] = [];
@@ -301,6 +309,10 @@ export default class NuPACK extends Folder {
 
                 cache.energy = (retA + retB) / 100;
             } else {
+                // If we have a sequence like AA&AA, NUPACK numbers the bases 1-4, but we
+                // number the bases 1-5 (counting the cut as a base), so we need to
+                // update the score node indices (ie, the starting base each node applies to)
+                // to be numbered according to our numbering scheme
                 for (let ii = 0; ii < seq.length; ii++) {
                     if (seq.nt(ii) === RNABase.CUT) {
                         for (let jj = 0; jj < cache.nodes.length; jj += 2) {

--- a/src/eterna/folding/__tests__/NuPACKMultistrand.test.ts
+++ b/src/eterna/folding/__tests__/NuPACKMultistrand.test.ts
@@ -1,0 +1,100 @@
+import SecStruct from "eterna/rnatypes/SecStruct";
+import Sequence from "eterna/rnatypes/Sequence";
+import Folder from "../Folder";
+import NuPACK from "../NuPACK";
+
+test(`NuPACK:Multifold`, () => {
+    expect.assertions(3);
+    return expect(NuPACK.create()
+        .then((folder) => {
+            if (folder === null) {
+                expect(true).toBeTruthy();
+                expect(true).toBeTruthy();
+                return;
+            }
+
+            let fold = (folder as Folder).multifold(
+                Sequence.fromSequenceString('UAAGUUCUGA'),
+                null,
+                [{
+                    malus: 9.934087678014993,
+                    name: 'A',
+                    sequence: Sequence.fromSequenceString('UCGGAACUUAGCUUAGAUGUGUGCAUUGAAUACGAGAUCUACAUGGUAGUUCGCUAUCAUGUAGAUUUCGUAUUCGAUGUGCACU').baseArray
+                }]
+            );
+
+            expect(fold).toBeDefined()
+            expect(fold!.pairs.getParenthesis()).toEqual('((((((((((.))))))))))........(((((((((((((((((((((((((((((((....))))))))))))))))))))))))))))))).');
+        }))
+        .resolves.toBeUndefined(); // (we're returning a promise)
+});
+
+test(`NuPACK:scoreStructures (multistrand)`, () => {
+    expect.assertions(3);
+    return expect(NuPACK.create()
+        .then((folder) => {
+            if (folder === null) {
+                expect(true).toBeTruthy();
+                expect(true).toBeTruthy();
+                return;
+            }
+
+            const nnfes: number[] = [];
+            const energy = folder.scoreStructures(
+                Sequence.fromSequenceString('UAAGUUCUGA&UCGGAACUUAGCUUAGAUGUGUGCAUUGAAUACGAGAUCUACAUGGUAGUUCGCUAUCAUGUAGAUUUCGUAUUCGAUGUGCACU', true),
+                SecStruct.fromParens('((((((((((.))))))))))........(((((((((((((((((((((((((((((((....))))))))))))))))))))))))))))))).'),
+                false,
+                37,
+                nnfes
+            );
+
+            expect(energy).toBe(-5452);
+            expect(nnfes).toEqual([
+                -2,  409,   -1, -200,   59,  210,   58, -170,   57, -110,   56,
+              -100,   55, -140,   54, -180,   53,  -90,   52, -180,   51, -210,
+                50, -110,   49, -170,   48, -230,   47,  -90,   46, -110,   45,
+               -50,   44, -230,   43, -200,   42, -210,   41, -110,   40,  -90,
+                39,  -90,   38, -230,   37, -120,   36, -110,   35,  -90,   34,
+              -180,   33, -210,   32,  -20,   31, -210,   30, -180,   29, -210,
+                 9,    0,    8, -230,    7, -120,    6, -190,    5, -230,    4,
+               -90,    3, -210,    2, -170,    1,  -90,    0, -110
+            ]);
+        }))
+        .resolves.toBeUndefined(); // (we're returning a promise)
+});
+
+test(`NuPACK:scoreStructures (multistrand, partially paired)`, () => {
+    expect.assertions(3);
+    return expect(NuPACK.create()
+        .then((folder) => {
+            if (folder === null) {
+                expect(true).toBeTruthy();
+                expect(true).toBeTruthy();
+                return;
+            }
+
+            const nnfes: number[] = [];
+            const energy = folder.scoreStructures(
+                Sequence.fromSequenceString('UAAGUUCUGA&UCGGAACUUAGCUUAGAUGGUUGCGUUGAAUUCGAGAUCUACAUGGUAGUUCGCUAUCAUGUAGAUUUCGGGUUCCAUCUGCAGU', true),
+                SecStruct.fromParens('................................((((..((((((((((((((((((((((....))))))))))))))))))))))....))))..'),
+                false,
+                37,
+                nnfes
+            );
+
+            expect(energy).toBe(-3171);
+            expect(nnfes).toEqual([
+                -1, -100, 59,  210, 58, -170, 57, -110,
+                56, -100, 55, -140, 54, -180, 53,  -90,
+                52, -180, 51, -210, 50, -110, 49, -170,
+                48, -230, 47,  -90, 46, -110, 45,  -50,
+                44, -230, 43, -200, 42, -140, 41,  -40,
+                40, -100, 39,  -90, 38, -230, 35,  330,
+                34, -120, 33, -340, 32, -180
+            ]);
+
+            console.log(energy);
+            console.log(nnfes);
+        }))
+        .resolves.toBeUndefined(); // (we're returning a promise)
+});

--- a/src/eterna/pose2D/RNALayout.ts
+++ b/src/eterna/pose2D/RNALayout.ts
@@ -1,4 +1,4 @@
-import EPars from 'eterna/EPars';
+import EPars, {RNABase} from 'eterna/EPars';
 import Folder from 'eterna/folding/Folder';
 import NuPACK from 'eterna/folding/NuPACK';
 import LayoutEngineManager from 'eterna/layout/LayoutEngineManager';
@@ -302,7 +302,7 @@ export default class RNALayout {
         } else {
             folder.scoreStructures(seq, this._origPairs, false, EPars.DEFAULT_TEMPERATURE, nnfe);
         }
-        this.scoreTreeRecursive(nnfe, this._root, null);
+        this.scoreTreeRecursive(nnfe, this._root, null, seq);
     }
 
     private addNodesRecursive(biPairs: number[], rootnode: RNATreeNode, startIndex: number, endIndex: number): void {
@@ -890,8 +890,14 @@ export default class RNALayout {
      * @param nnfe list of nearest neighbor free energies
      * @param rootnode current node for consideration
      * @param parentnode parent of roonode, null if rootnode is root_
+     * @param seq the sequence of the structure being scored
      */
-    private scoreTreeRecursive(nnfe: number[], rootnode: RNATreeNode, parentnode: RNATreeNode | null): void {
+    private scoreTreeRecursive(
+        nnfe: number[],
+        rootnode: RNATreeNode,
+        parentnode: RNATreeNode | null,
+        seq: Sequence
+    ): void {
         if (rootnode.isPair) {
             // / Pair node
             if (rootnode.children.length > 1) {
@@ -903,10 +909,10 @@ export default class RNALayout {
             }
 
             if (rootnode.children[0].isPair) {
-                rootnode.score = RNALayout.lookupFe(nnfe, rootnode.indexA);
+                rootnode.score = this.lookupFe(nnfe, seq, rootnode.indexA);
             }
 
-            this.scoreTreeRecursive(nnfe, rootnode.children[0], rootnode);
+            this.scoreTreeRecursive(nnfe, rootnode.children[0], rootnode, seq);
         } else if (!rootnode.isPair && rootnode.indexA >= 0) {
             // / Single residue node
 
@@ -915,8 +921,8 @@ export default class RNALayout {
 
             // / Top root case
             if (parentnode == null) {
-                // / initial ml scoring
-                rootnode.score = RNALayout.lookupFe(nnfe, -1) + RNALayout.lookupFe(nnfe, -2);
+                // The energy value at index -1 is the dangle energy
+                rootnode.score = this.lookupFe(nnfe, seq, -1);
             } else if (!parentnode.isPair) {
                 throw new Error('Parent node must be a pair');
             }
@@ -935,15 +941,15 @@ export default class RNALayout {
             }
 
             if (numStacks === 1 && parentnode != null) {
-                rootnode.score = RNALayout.lookupFe(nnfe, parentnode.indexA);
+                rootnode.score = this.lookupFe(nnfe, seq, parentnode.indexA);
             } else if (numStacks === 0 && parentnode != null) {
-                rootnode.score = RNALayout.lookupFe(nnfe, parentnode.indexA);
+                rootnode.score = this.lookupFe(nnfe, seq, parentnode.indexA);
             } else if (numStacks > 1 && parentnode != null) {
-                rootnode.score = RNALayout.lookupFe(nnfe, parentnode.indexA);
+                rootnode.score = this.lookupFe(nnfe, seq, parentnode.indexA);
             }
 
             for (const child of rootnode.children) {
-                this.scoreTreeRecursive(nnfe, child, rootnode);
+                this.scoreTreeRecursive(nnfe, child, rootnode, seq);
             }
         }
     }
@@ -951,12 +957,23 @@ export default class RNALayout {
     // / FIXME: there's surely a smarter way to do this...
     /**
      * Find a particular nnfe element. Why isn't this a dict? Right now it is a
-     * list of pairs, basically... is JS dict lookup superlinear?
+     * list of pairs, basically... is JS dict lookup superlinear? EDIT: This is
+     * due to how nnfes are retrieved from the folding engine. We insert a callback
+     * which adds two elements (the starting index of a substructure and the energy value)
+     * to an array, and that array winds up getting passed straight through to here. This
+     * may be a holdover from Flash/Alchemy limitations. In theory we should be able to
+     * change it to a map starting in C++ and propagate that change all the way to here.
      *
      * @param nnfe Array of nearest neighbor parameters
      * @param index A desired index from the structure, for which we must search
      */
-    private static lookupFe(nnfe: number[], index: number): number {
+    private lookupFe(nnfe: number[], seq: Sequence, index: number): number {
+        if (index >= 0 && index < seq.length && seq.nt(index + 1) === RNABase.CUT) {
+            // The energy at index -2 is a term for multistrand sequences
+            // We'll distribute that term among energy nodes placed at cut points
+            return this.lookupFe(nnfe, seq, -2) / seq.numCuts();
+        }
+
         for (let ii = 0; ii < nnfe.length - 1; ii += 2) {
             if (nnfe[ii] === index) return nnfe[ii + 1];
         }

--- a/src/eterna/pose2D/RNALayout.ts
+++ b/src/eterna/pose2D/RNALayout.ts
@@ -916,7 +916,7 @@ export default class RNALayout {
             // / Top root case
             if (parentnode == null) {
                 // / initial ml scoring
-                rootnode.score = RNALayout.lookupFe(nnfe, -1);
+                rootnode.score = RNALayout.lookupFe(nnfe, -1) + RNALayout.lookupFe(nnfe, -2);
             } else if (!parentnode.isPair) {
                 throw new Error('Parent node must be a pair');
             }

--- a/src/eterna/pose2D/__tests__/RNALayout.test.ts
+++ b/src/eterna/pose2D/__tests__/RNALayout.test.ts
@@ -1,5 +1,45 @@
-import RNALayout from '../RNALayout';
+import RNALayout, {RNATreeNode} from '../RNALayout';
 import SecStruct from 'eterna/rnatypes/SecStruct';
+import Sequence from 'eterna/rnatypes/Sequence';
+import Folder from 'eterna/folding/Folder';
+import FoldUtil from 'eterna/folding/FoldUtil';
+
+class MockFolder extends Folder {
+    name = 'MockFolder';
+
+    public get isFunctional(): boolean {
+        return true;
+    }
+
+    public scoreStructures(_seq: Sequence, _secstruct: SecStruct, _pseudoknotted?: boolean, _temp?: number, outNodes?: number[] | null): number {
+        // See NuPACK:scoreStructures (multistrand) in src/eterna/folding/__tests__/NuPACKMultistrand.test.ts
+        if (outNodes != null) {
+            FoldUtil.arrayCopy(outNodes, [
+                -2,  409,   -1, -200,   59,  210,   58, -170,   57, -110,   56,
+              -100,   55, -140,   54, -180,   53,  -90,   52, -180,   51, -210,
+                50, -110,   49, -170,   48, -230,   47,  -90,   46, -110,   45,
+               -50,   44, -230,   43, -200,   42, -210,   41, -110,   40,  -90,
+                39,  -90,   38, -230,   37, -120,   36, -110,   35,  -90,   34,
+              -180,   33, -210,   32,  -20,   31, -210,   30, -180,   29, -210,
+                 9,    0,    8, -230,    7, -120,    6, -190,    5, -230,    4,
+               -90,    3, -210,    2, -170,    1,  -90,    0, -110
+            ]);
+        }
+        return -5452;
+    }
+}
+
+interface ScoreTreeJSON {
+    score: number;
+    children: ScoreTreeJSON[];
+}
+
+function scoreTreeToJSON(node: RNATreeNode): ScoreTreeJSON {
+    return {
+        score: node.score,
+        children: node.children.map(child => scoreTreeToJSON(child))
+    };
+}
 
 test(`RNALayout:setupTree`, () => {
     const rnalayout: RNALayout = new RNALayout();
@@ -8,4 +48,17 @@ test(`RNALayout:setupTree`, () => {
     const pairs = new SecStruct([10, 9, 8, -1, -1, -1, -1, 3, 2, 1]);
     rnalayout.setupTree(pairs);
     expect(rnalayout["_scoreBiPairs"][0]).toBe(11);
+});
+
+test('RNALayout:scoreTree (multistrand)', () => {
+    const scoreTree: RNALayout = new RNALayout();
+    const pairs = SecStruct.fromParens('((((((((((.))))))))))........(((((((((((((((((((((((((((((((....))))))))))))))))))))))))))))))).');
+    scoreTree.setupTree(pairs);
+
+    const seq = Sequence.fromSequenceString('UAAGUUCUGA&UCGGAACUUAGCUUAGAUGGUUGCGUUGAAUUCGAGAUCUACAUGGUAGUUCGCUAUCAUGUAGAUUUCGGGUUCCAUCUGCAGU', true);
+    scoreTree.scoreTree(seq, new MockFolder());
+
+    expect(scoreTreeToJSON(scoreTree.root!)).toEqual(
+        {"score":-200,"children":[{"score":-110,"children":[{"score":-90,"children":[{"score":-170,"children":[{"score":-210,"children":[{"score":-90,"children":[{"score":-230,"children":[{"score":-190,"children":[{"score":-120,"children":[{"score":-230,"children":[{"score":0,"children":[{"score":409,"children":[{"score":0,"children":[]}]}]}]}]}]}]}]}]}]}]}]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":-210,"children":[{"score":-180,"children":[{"score":-210,"children":[{"score":-20,"children":[{"score":-210,"children":[{"score":-180,"children":[{"score":-90,"children":[{"score":-110,"children":[{"score":-120,"children":[{"score":-230,"children":[{"score":-90,"children":[{"score":-90,"children":[{"score":-110,"children":[{"score":-210,"children":[{"score":-200,"children":[{"score":-230,"children":[{"score":-50,"children":[{"score":-110,"children":[{"score":-90,"children":[{"score":-230,"children":[{"score":-170,"children":[{"score":-110,"children":[{"score":-210,"children":[{"score":-180,"children":[{"score":-90,"children":[{"score":-180,"children":[{"score":-140,"children":[{"score":-100,"children":[{"score":-110,"children":[{"score":-170,"children":[{"score":0,"children":[{"score":210,"children":[{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]},{"score":0,"children":[]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]},{"score":0,"children":[]}]}   
+    );
 });

--- a/src/eterna/rnatypes/Sequence.ts
+++ b/src/eterna/rnatypes/Sequence.ts
@@ -308,6 +308,13 @@ export default class Sequence {
         return this._baseArray.lastIndexOf(RNABase.CUT);
     }
 
+    /**
+     * The number of cuts in this sequence
+     */
+    public numCuts(): number {
+        return this._baseArray.filter((base) => base === RNABase.CUT).length;
+    }
+
     public get baseArray(): RNABase[] {
         return this._baseArray;
     }


### PR DESCRIPTION
* Fix substructure energies being paced at the wrong locations. Start base indices of score nodes were incorrectly offset to account for cut points
* Fix missing substructure energies/very large total energy values in situations with disconnected strands. When computing energy with a disconnected strand, secondary strands had their bases shifted twice when computing strand energies separately
* Fix delta/total free energy mismatch (which wound up being incorrect total free energy values). The root node of a scored RNA tree didn't account for the multistrand energy adjustment

Big thanks to @LunarFawn for doing the initial investigation and pairing with me on this!

Resolves #658 