### PR TITLE
Don't attempt to animate bases on mutate when in simple graphics mode

### DIFF
--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -3431,7 +3431,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         this._bases[seqpos].setType(inColor, true);
 
         this._lastColoredIndex = seqpos;
-        this._bases[seqpos].animate();
+        if (!this._simpleGraphicsMode) this._bases[seqpos].animate();
         this.doneColoring();
     }
 
@@ -3799,7 +3799,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
             }
         }
         this._lastColoredIndex = seqnum;
-        this._bases[seqnum].animate();
+        if (!this._simpleGraphicsMode) this._bases[seqnum].animate();
     }
 
     private updateDesignHighlight(): void {


### PR DESCRIPTION
## Summary
When in simple graphics mode, if you mutate a base, it would slightly offset the base positions

## Implementation Notes
This was because we perform the same animation we use randomly over time on loops whenever you mutate a base. However, in low performance mode, a future update sets the animation to disabled, causing just a slight base movement. This patch checks if simple graphics mode is enabled before attempting to start animating

## Testing
Manual
