### PR TITLE
Allow design header text to be selected/copied

### DIFF
--- a/src/eterna/mode/DesignBrowser/ViewSolutionOverlay.ts
+++ b/src/eterna/mode/DesignBrowser/ViewSolutionOverlay.ts
@@ -197,23 +197,19 @@ export default class ViewSolutionOverlay extends ContainerObject {
         this._content.addObject(title, this._header);
         this._header.addVSpacer(20);
 
-        const solutionName = Fonts.std()
-            .bold()
-            .text(this._props.solution.title)
-            .fontSize(24)
-            .color(0xffffff)
-            .wordWrap(true, theme.width - theme.margin.left - theme.margin.right)
-            .build();
-        this._header.addChild(solutionName);
+        const solutionName = new HTMLTextObject(
+            this._props.solution.title,
+            theme.width - theme.margin.left - theme.margin.right
+        );
+        solutionName.bold().fontSize(24).color(0xffffff);
+        this.addObject(solutionName, this._header);
 
-        const playerName = Fonts.std()
-            .bold()
-            .text(`By ${this._props.solution.playerName}`)
-            .fontSize(18)
-            .color(0xffffff)
-            .wordWrap(true, theme.width - theme.margin.left - theme.margin.right)
-            .build();
-        this._header.addChild(playerName);
+        const playerName = new HTMLTextObject(
+            `By ${this._props.solution.playerName}`,
+            theme.width - theme.margin.left - theme.margin.right
+        );
+        playerName.bold().fontSize(18).color(0xffffff);
+        this.addObject(playerName, this._header);
         this._header.addVSpacer(5);
 
         // Links


### PR DESCRIPTION
## Summary
The design name and author in the solution sidebar are now able to be selected and copied, which can be desirable by players.

## Implementation Notes
This moves from using bitmap text to HTML text, as HTML text can be selected/copied natively. The header is not in a masked container (it's not part of the scroll container), so it can use the default global parent container.

## Testing
Manual

## Related Issues
(Reported in Slack by Jennifer Pearl)
