### PR TITLE
Fix sections of design browser columns not being clickable

### DIFF
--- a/src/eterna/mode/DesignBrowser/DataCol.ts
+++ b/src/eterna/mode/DesignBrowser/DataCol.ts
@@ -532,7 +532,7 @@ export default class DataCol extends ContainerObject {
         const {designBrowser: theme} = UITheme;
         this._graphics.clear();
         // Data
-        this._graphics.beginFill(this._fillColor, this._fillAlpha);
+        this._graphics.beginFill(this._fillColor, Math.max(this._fillAlpha, 0.001));
         this._graphics.drawRect(
             1,
             theme.headerHeight + theme.filterHeight + 1,


### PR DESCRIPTION
## Summary
For the "darker" design browser columns (which don't have a semi-transparent white background), clicking or hovering over areas without content would previously not trigger mouse events for the relevant rows. 

## Implementation Notes
This is a regression due to a change in Pixi 6 affecting undefined behavior of whether graphics drawn with an alpha of 0 would be included in a hit test for mouse events. In other areas of the code, we draw the graphics with a higher alpha on the fill and then change the alpha of the graphics, but in this case the graphics contains portions which should not be affected by the alpha, so the simplest solution is making the alpha very small but not zero (which especially in this scenario is imperceptible).

## Testing
Manual
