### PR TITLE
Increase height of body of lock icon

### DIFF
--- a/assets/RNABase/base-lock.svg
+++ b/assets/RNABase/base-lock.svg
@@ -24,7 +24,7 @@
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
      inkscape:zoom="8"
-     inkscape:cx="56"
+     inkscape:cx="51.875"
      inkscape:cy="44.375"
      inkscape:window-width="3440"
      inkscape:window-height="1367"
@@ -38,13 +38,13 @@
      id="path581"
      sodipodi:nodetypes="ccczcccczcc" />
   <rect
-     style="fill:#050505;fill-opacity:1;stroke:none;stroke-width:2.68842"
+     style="fill:#050505;fill-opacity:1;stroke:none;stroke-width:2.75107"
      id="rect1241"
      width="44.76144"
-     height="39.169338"
+     height="41.016376"
      x="9.6192799"
-     y="24.830662"
-     ry="16.414154" />
+     y="22.983624"
+     ry="17.188166" />
   <rect
      style="fill:#111111;fill-opacity:1;stroke:none"
      id="rect1495"


### PR DESCRIPTION
## Summary
This is a super subtle change, but by making the height of the "body" of the lock slightly larger (relative to the height of the shackle and the width of the body), it helps the icon to read a bit more clearly

First image is the new version, second is the old version
![image](https://user-images.githubusercontent.com/18635705/228566613-96d7ee96-eba6-4790-9a3d-b82c0867afbd.png)
![image](https://user-images.githubusercontent.com/18635705/228566682-415d477c-e25c-459d-8ed0-978c74e46f48.png)

## Related Issues
Followup to #679