### PR TITLE
Support variable barcode lengths

### DIFF
--- a/src/eterna/puzzle/Puzzle.ts
+++ b/src/eterna/puzzle/Puzzle.ts
@@ -402,6 +402,10 @@ export default class Puzzle {
         this._barcodeStart = start;
     }
 
+    public set barcodeLength(length: number) {
+        this._barcodeLength = length;
+    }
+
     public get barcodeIndices(): number[] | null {
         if (!this._useBarcode) {
             return null;
@@ -409,19 +413,21 @@ export default class Puzzle {
 
         const secstruct: string = this.getSecstruct();
 
+        const barcodeLength = this._barcodeLength ?? 7;
+
         let barcodeStart: number;
         if (this._barcodeStart) {
             barcodeStart = this._barcodeStart;
         } else if (this._useTails) {
             // Last 7 bases before the 20-base tail (which is actually always 21 bases
             // apparently - all cloud labs have defined an extra locked A just before the tail)
-            barcodeStart = secstruct.length - 20 - 7 - 1;
+            barcodeStart = secstruct.length - 20 - barcodeLength - 1;
         } else {
             // Last 7 bases
-            barcodeStart = secstruct.length - 7;
+            barcodeStart = secstruct.length - barcodeLength;
         }
 
-        return Utility.range(barcodeStart, barcodeStart + 7);
+        return Utility.range(barcodeStart, barcodeStart + barcodeLength);
     }
 
     public getBarcodeHairpin(seq: Sequence): Sequence {
@@ -675,6 +681,7 @@ export default class Puzzle {
     private _useShortTails: boolean = false;
     private _useBarcode: boolean = false;
     private _barcodeStart: number | null = null;
+    private _barcodeLength: number | null = null;
     private _targetConditions: TargetConditions[] | null = null;
     // With no oligos, this is correctly empty. We'll set it when we set objectives
     private _oligoLengths: Map<string, number> = new Map();

--- a/src/eterna/puzzle/PuzzleManager.ts
+++ b/src/eterna/puzzle/PuzzleManager.ts
@@ -64,6 +64,7 @@ export interface PuzzleJSON {
     'last-round'?: string;
     check_hairpin?: string;
     barcode_start?: string;
+    barcode_length?: string;
     'num-submissions'?: string;
     rscript?: string;
     events?: string;
@@ -170,6 +171,10 @@ export default class PuzzleManager {
 
         if (json['barcode_start']) {
             newpuz.barcodeStart = Number(json['barcode_start']);
+        }
+
+        if (json['barcode_length']) {
+            newpuz.barcodeLength = Number(json['barcode_length']);
         }
 
         if (json['num-submissions'] != null) {


### PR DESCRIPTION
## Summary
Going forward, we are expecting to have synthesis runs that would have more sequences than we could currently make unique barcodes for with only a barcode of length 7. This takes the recent backend update adding a barcode length field and uses it when determining the barcode indices, falling back to the previous value of 7 if not specified.

## Implementation Notes
This logic mirrors the updated backend logic. I've opted to have the barcode "count back" from the tail if a barcode start is not specified in order to be more robust. Behavior if the barcode is placed past the end of the RNA remains unhandled, and is considered a reasonable setup error.

## Testing
Ensured proper validation behavior in the following scenarios:
* No barcode start or length, unused barcode
* No barcode start or length, used barcode
* Barcode length without start, unused barcode
* Barcode length without start, used barcode
* Barcode length and start, unused barcode
* Barcode length and start, used barcode

## Related Issues
This is a companion to commit 9cacd73a7cd6384341be4c2d978bb313ce8f1a8d on the legacy website