### PR TITLE
Update WASM components to compile + load under newer emscripten versions

### DIFF
--- a/lib/EternaFold/CMakeLists.txt
+++ b/lib/EternaFold/CMakeLists.txt
@@ -67,7 +67,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(eternafold PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"eternafold\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 --embed-file EternaFold/parameters@/")
+    set_target_properties(eternafold PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"eternafold\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB --embed-file EternaFold/parameters@/")
     set_target_properties(eternafold PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(eternafold PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()

--- a/lib/LinearFold/CMakeLists.txt
+++ b/lib/LinearFold/CMakeLists.txt
@@ -71,7 +71,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
   #
   # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
   # -s SAFE_HEAP=1
-  set(BASE_LINK_FLAGS "-s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1")
+  set(BASE_LINK_FLAGS "-s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB")
   set_target_properties(LinearFoldV    PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"LinearFoldV\"' ${BASE_LINK_FLAGS}")
   set_target_properties(LinearFoldC    PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"LinearFoldC\"' ${BASE_LINK_FLAGS}")
   if (EXISTS "../EternaFold/EternaFold/parameters/LinearFold/feature_weight_e.h")

--- a/lib/NUPACK/CMakeLists.txt
+++ b/lib/NUPACK/CMakeLists.txt
@@ -58,7 +58,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(nupack PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"nupack\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 --embed-file nupack3.0.4/parameters@/")
+    set_target_properties(nupack PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"nupack\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB -s EXPORTED_RUNTIME_METHODS='[\"callMain\"]' --embed-file nupack3.0.4/parameters@/")
     set_target_properties(nupack PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(nupack PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()

--- a/lib/RNApuzzler/CMakeLists.txt
+++ b/lib/RNApuzzler/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -I/Users/andrewwatkins/programs/emsdk/upstream/emscripten/system/include")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g2")
 
@@ -106,7 +106,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(rnapuzzler PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"rnapuzzler\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1")
+    set_target_properties(rnapuzzler PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"rnapuzzler\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB")
     set_target_properties(rnapuzzler PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(rnapuzzler PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()

--- a/lib/Vienna1/CMakeLists.txt
+++ b/lib/Vienna1/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+set(CMAKE_C_FLAGS "-Wno-error=implicit-int -Wno-error=int-conversion")
 set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g2")
@@ -66,7 +67,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(vienna PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"vienna\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1")
+    set_target_properties(vienna PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"vienna\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB")
     set_target_properties(vienna PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(vienna PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()

--- a/lib/Vienna2/CMakeLists.txt
+++ b/lib/Vienna2/CMakeLists.txt
@@ -9,7 +9,8 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -I/Users/andrewwatkins/programs/emsdk/upstream/emscripten/system/include")
+set(CMAKE_C_FLAGS "-Wno-error=implicit-int -Wno-error=int-conversion")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g2")
 
@@ -81,7 +82,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(vienna2 PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"vienna2\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1")
+    set_target_properties(vienna2 PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"vienna2\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB")
     set_target_properties(vienna2 PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(vienna2 PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()

--- a/lib/contrafold/CMakeLists.txt
+++ b/lib/contrafold/CMakeLists.txt
@@ -66,7 +66,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(contrafold PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"contrafold\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 ")
+    set_target_properties(contrafold PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"contrafold\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB")
     set_target_properties(contrafold PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(contrafold PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()

--- a/src/eterna/emscripten/EmscriptenUtil.ts
+++ b/src/eterna/emscripten/EmscriptenUtil.ts
@@ -7,25 +7,12 @@ export default class EmscriptenUtil {
      * Instantiates a program from an Emscripten module and calls its main() function if it has one.
      * @returns {Promise<any>} a promise that will resolve with the instantiated module.
      */
-    public static loadProgram(module: any): Promise<any> {
-        return new Promise<any>((resolve, _) => {
-            module.default({noInitialRun: true}).then((program: any) => {
-                if (Object.prototype.hasOwnProperty.call(program, 'callMain')) {
-                    program.callMain();
-                }
-
-                // Fix an infinite loop.
-                // "program" is not a promise, but since it has a 'then' property,
-                // resolving our promise with the program will recurse infinitely.
-                // https://github.com/kripken/emscripten/issues/5820
-                // TODO: remove this if and when emscripten is fixed
-                if (Object.prototype.hasOwnProperty.call(program, 'then')) {
-                    delete program['then'];
-                }
-
-                resolve(program);
-            });
-        });
+    public static async loadProgram(module: any): Promise<any> {
+        const program = await module.default({noInitialRun: true});
+        if (Object.prototype.hasOwnProperty.call(program, 'callMain')) {
+            program.callMain();
+        }
+        return program;
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
 


### PR DESCRIPTION
## Summary
This includes a handful of changes to account for recent(ish) changes in Emscripten that caused issues when compiling with newer versions

## Implementation Notes
* In 3.1.27 (released 11/29/22), the default stack size was reduced from 5MB to 64KB. We need larger available stack space, so we revert this setting
* In v1.38.41 (released 08/07/2019), callMain was no longer exported by default. Only nupack exports a main function we intend to call, so we enabled it specifically for that module
* `-Wimplicit-int` and `-Wint-conversion` were enabled, but cause errors in vendor Vienna code. We revert those errors to warnings.
* In 1.39.16 (released 05/15/2020), Emscripten modules now provide an actual promise instead of a "promise-like" interface, which we now use 

## Testing
Basic sanity checks loading puzzles, unit tests