### PR TITLE
Increase nupack maximum memory to 4GB

### DIFF
--- a/lib/NUPACK/CMakeLists.txt
+++ b/lib/NUPACK/CMakeLists.txt
@@ -58,7 +58,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
     #
     # Debugging tools (see https://github.com/kripken/emscripten/blob/master/src/settings.js):
     # -s SAFE_HEAP=1
-    set_target_properties(nupack PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"nupack\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB -s EXPORTED_RUNTIME_METHODS='[\"callMain\"]' --embed-file nupack3.0.4/parameters@/")
+    set_target_properties(nupack PROPERTIES LINK_FLAGS "-s 'EXPORT_NAME=\"nupack\"' -s MODULARIZE=1 --bind -std=c++11 -s SINGLE_FILE=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB -s MAXIMUM_MEMORY=4GB -s EXPORTED_RUNTIME_METHODS='[\"callMain\"]' --embed-file nupack3.0.4/parameters@/")
     set_target_properties(nupack PROPERTIES LINK_FLAGS_DEBUG "-O0 -s WASM=0 -s DEMANGLE_SUPPORT=1 -s ASSERTIONS=2 -s SAFE_HEAP=1")
     set_target_properties(nupack PROPERTIES LINK_FLAGS_RELEASE "-O3 -s WASM=1")
 endif ()


### PR DESCRIPTION
## Summary
On the PK100 test puzzle (177 bases with pseudoknots enabled), we were getting memory allocation failures due to more memory being requested than available. By default, Emscripten has a memory limit of 2GB. Increasing to 4GB allows this puzzle to run, though this amount of memory usage could be problematic on lower-end devices (already, mobile devices were failing to load the PK90 within the old memory limit).

## Implementation Notes
See https://github.com/emscripten-core/emscripten/blob/de7cbc56c3ac38b83cc3e8bbc17ac5fbb6b3bbd7/src/settings.js#L155-L175 for additional details on this parameter

## Testing
PK100 now loads
