### PR TITLE
Bump prebuilt folding engine dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "webpack-merge": "^5.7.3"
       },
       "optionalDependencies": {
-        "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#74ec003dfb72b30aaffdc3cea187227328dbbb2e"
+        "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#cad1c24dba21a12b3219648b866e1042a64d8403"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6779,8 +6779,9 @@
       "license": "ISC"
     },
     "node_modules/eternajs-folding-engines": {
-      "version": "1.9.0",
-      "resolved": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#74ec003dfb72b30aaffdc3cea187227328dbbb2e",
+      "version": "1.9.1",
+      "resolved": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#cad1c24dba21a12b3219648b866e1042a64d8403",
+      "integrity": "sha512-PLqecDhDFD6LS/l2Q2eaKhtrwZMtZFfWkhmoOk/+ekrCryKwpTNxPRVoj4fgfW8gNcaOGps6u+RmHyTKSuAeJw==",
       "optional": true
     },
     "node_modules/eventemitter3": {
@@ -18935,8 +18936,9 @@
       "integrity": "sha512-2yhrfFLMgmjUS3fCEOIxD7RXjQPv7/ZItlaI7xit0g1eAWGst8f+zXBCMDoyMN5tjYHQ2mrvGJ1v2u6w9g7OIQ=="
     },
     "eternajs-folding-engines": {
-      "version": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#74ec003dfb72b30aaffdc3cea187227328dbbb2e",
-      "from": "eternajs-folding-engines@github:eternagame/eternajs-folding-engines#74ec003dfb72b30aaffdc3cea187227328dbbb2e",
+      "version": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#cad1c24dba21a12b3219648b866e1042a64d8403",
+      "integrity": "sha512-PLqecDhDFD6LS/l2Q2eaKhtrwZMtZFfWkhmoOk/+ekrCryKwpTNxPRVoj4fgfW8gNcaOGps6u+RmHyTKSuAeJw==",
+      "from": "eternajs-folding-engines@github:eternagame/eternajs-folding-engines#cad1c24dba21a12b3219648b866e1042a64d8403",
       "optional": true
     },
     "eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     ]
   },
   "optionalDependencies": {
-    "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#74ec003dfb72b30aaffdc3cea187227328dbbb2e"
+    "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#cad1c24dba21a12b3219648b866e1042a64d8403"
   }
 }


### PR DESCRIPTION
## Summary
Bumps optional dependency for prebuilt folding engines, including changes from https://github.com/eternagame/EternaJS/pull/686 and https://github.com/eternagame/EternaJS/pull/687