### PR TITLE
Support structure copy and paste target structure

### DIFF
--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -549,6 +549,7 @@ export default class FeedbackViewMode extends GameMode {
         }
 
         this.updateCopySequenceDialog();
+        this.updateCopyStructureDialog();
     }
 
     private showExperimentalColors(): void {

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -636,7 +636,7 @@ export default class PuzzleEditMode extends GameMode {
     }
 
     /* override */
-    protected createContextMenu(): ContextMenu | null {
+    protected createContextMenu(poseIdx: number): ContextMenu | null {
         if (this.isDialogOrNotifShowing || this.hasUILock) {
             return null;
         }
@@ -647,6 +647,7 @@ export default class PuzzleEditMode extends GameMode {
         menu.addItem('Reset').clicked.connect(() => this.promptForReset());
         menu.addItem('Copy Sequence').clicked.connect(() => this.showCopySequenceDialog());
         menu.addItem('Paste Sequence').clicked.connect(() => this.showPasteSequenceDialog());
+        menu.addItem('Copy Structure').clicked.connect(() => this.showCopyStructureDialog(poseIdx));
 
         return menu;
     }
@@ -1053,6 +1054,7 @@ export default class PuzzleEditMode extends GameMode {
         this._toolbar.palette.setPairCounts(numAU, numGU, numGC);
 
         this.updateCopySequenceDialog();
+        this.updateCopyStructureDialog();
     }
 
     private onPaletteTargetSelected(type: PaletteTargetType): void {

--- a/src/eterna/ui/PasteStructureDialog.ts
+++ b/src/eterna/ui/PasteStructureDialog.ts
@@ -1,0 +1,104 @@
+import {VLayoutContainer} from 'flashbang';
+import {Signal} from 'signals';
+import {Text} from 'pixi.js';
+import Fonts from 'eterna/util/Fonts';
+import SecStruct from 'eterna/rnatypes/SecStruct';
+import WindowDialog from './WindowDialog';
+import TextInputGrid from './TextInputGrid';
+import GameButton from './GameButton';
+import TextInputObject from './TextInputObject';
+
+interface PasteResult {
+    structure: SecStruct;
+    startAt: number;
+}
+
+export default class PasteStructureDialog extends WindowDialog<void> {
+    public readonly applyClicked: Signal<PasteResult> = new Signal();
+
+    constructor(pseudoknots: boolean) {
+        super({title: 'Paste a structure'});
+        this._pseudoknots = pseudoknots;
+    }
+
+    protected added(): void {
+        super.added();
+
+        this._content = new VLayoutContainer(20);
+        this._window.content.addChild(this._content);
+
+        this._errorText = Fonts.std()
+            .fontSize(14)
+            .color(0xff7070)
+            .bold()
+            .build();
+        this._errorText.visible = false;
+        this._content.addChild(this._errorText);
+
+        const inputGrid = new TextInputGrid(undefined, this._window.contentHtmlWrapper);
+        this._structureField = inputGrid.addField('Structure', 200);
+        this._startAtField = inputGrid.addField('Starting base', 50);
+        this.addObject(inputGrid, this._content);
+
+        const applyButton = new GameButton().label('Apply', 14);
+        this.addObject(applyButton, this._content);
+
+        applyButton.clicked.connect(() => this.onApply(this._structureField.text, this._startAtField.text));
+        this.regs.add(this._structureField.keyPressed.connect((key) => {
+            if (key === 'Enter') this.onApply(this._structureField.text, this._startAtField.text);
+        }));
+        this.regs.add(this._startAtField.keyPressed.connect((key) => {
+            if (key === 'Enter') this.onApply(this._structureField.text, this._startAtField.text);
+        }));
+
+        this._content.layout();
+        this._window.layout();
+    }
+
+    private onApply(structure: string, startAtStr: string): void {
+        const prevText = this._errorText.text;
+        const wasVisible = this._errorText.visible;
+
+        const startAt = startAtStr ? parseInt(startAtStr, 10) : 1;
+
+        const validStruct = /^[.()[\]{}<>]+$/.test(structure);
+        if (structure.length === 0) {
+            this._errorText.text = 'Please enter a structure';
+            this._errorText.visible = true;
+        } else if (!validStruct) {
+            this._errorText.text = 'You can only use the following characters: .()[]{}<>';
+            this._errorText.visible = true;
+        } else if (Number.isNaN(startAt)) {
+            this._errorText.text = 'Please enter a valid number for the starting base';
+            this._errorText.visible = true;
+        } else {
+            let s;
+            try {
+                s = SecStruct.fromParens(structure, this._pseudoknots);
+            } catch (e: unknown) {
+                if (e instanceof Error) {
+                    this._errorText.text = e.message;
+                    this._errorText.visible = true;
+                } else throw e;
+            }
+            if (s) {
+                this._errorText.visible = false;
+                this.applyClicked.emit({structure: s, startAt});
+            }
+        }
+
+        this._structureField.setFocus(true);
+
+        if (this._errorText.visible !== wasVisible || prevText !== this._errorText.text) {
+            this._content.layout(true);
+            this._window.layout();
+        }
+    }
+
+    private _pseudoknots: boolean;
+
+    private _content: VLayoutContainer;
+    private _errorText: Text;
+    private _structureField: TextInputObject;
+    private _startAtField: TextInputObject;
+}


### PR DESCRIPTION
## Summary
Using magic glue to specify a target structure can be painful if you already have a particular target structure in mind that requires many changes, especially if loading from an external tool. This allows for a dot bracket target structure to be pasted directly.

Multiple users have also requested being able to copy structures, and this will also help if wanting to make the target structure match the current natural structure.

## Implementation Notes
Currently this has just been added to the context menu (to expedite not needing a new icon, etc and also because for puzzles with pip mode, it's the quickest way that came to mind to figure out which state to apply to). The UX could definitely use improvement.

## Testing
* Copied target and natural structures
* Pasted alternative structure changing constrained regions with and without specified start base
* Pasted alternative structure changing unconstrained regions with and without specified start base

## Related Issues
https://forum.eternagame.org/t/copy-and-paste-secondary-structure-string/2241/3
