### PR TITLE
Add Eternafold + Threshknot folding engine

### DIFF
--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -26,6 +26,7 @@ import Vienna2 from './folding/Vienna2';
 import NuPACK from './folding/NuPACK';
 import Contrafold from './folding/Contrafold';
 import EternaFold from './folding/Eternafold';
+import EternaFoldThreshknot from './folding/EternafoldThreshknot';
 import RNAFoldBasic from './folding/RNAFoldBasic';
 import FolderManager from './folding/FolderManager';
 import LayoutEngineManager from './layout/LayoutEngineManager';
@@ -558,6 +559,7 @@ export default class EternaApp extends FlashbangApp {
             LinearFoldV.create(),
             Contrafold.create(),
             EternaFold.create(),
+            EternaFoldThreshknot.create(),
             RNAFoldBasic.create()])
             .then((folders: (Folder | null)[]) => {
                 log.info('Folding engines intialized');

--- a/src/eterna/folding/Eternafold.ts
+++ b/src/eterna/folding/Eternafold.ts
@@ -27,7 +27,7 @@ export default class EternaFold extends Folder {
             .catch((_err) => null);
     }
 
-    private constructor(lib: EternafoldLib) {
+    protected constructor(lib: EternafoldLib) {
         super();
         this._lib = lib;
     }
@@ -160,7 +160,7 @@ export default class EternaFold extends Folder {
         return pairs;
     }
 
-    private foldSequenceImpl(
+    protected foldSequenceImpl(
         seq: Sequence,
         _structStr: string | null = null,
         _temp: number = 37,
@@ -217,5 +217,5 @@ export default class EternaFold extends Folder {
         return new DotPlot(retArray);
     }
 
-    private readonly _lib: EternafoldLib;
+    protected readonly _lib: EternafoldLib;
 }

--- a/src/eterna/folding/EternafoldThreshknot.ts
+++ b/src/eterna/folding/EternafoldThreshknot.ts
@@ -65,6 +65,7 @@ export default class EternaFoldThreshknot extends EternaFold {
             seq: seq.sequenceString(),
             secondBestPairs: secondBestPairs?.pairs ?? null,
             desiredPairs,
+            pseudoknotted,
             temp,
             gamma
         };

--- a/src/eterna/folding/__tests__/EternafoldThreshknot.test.ts
+++ b/src/eterna/folding/__tests__/EternafoldThreshknot.test.ts
@@ -3,6 +3,7 @@ import Folder from '../Folder';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 import EternaFoldThreshknot from 'eterna/folding/EternafoldThreshknot';
+import EternaFold from 'eterna/folding/Eternafold';
 
 function CreateFolder(type: any): Promise<Folder | null> {
     return type.create();
@@ -15,13 +16,15 @@ test(`EternaFoldThreshknot:folds_structures`, () => {
         "GGGGGGGGAAAACGGAAAGCCACCCCCC",
         "CCCAGGUCGUAGAACUAAAGCGCCAAAAGGACGCAAUUAGAACUACAUGCAUAGCAUGACCAAAGGG",
         "CCUACUAGGGGAGCCAAAAGGCUGAGAUGAAUGUAUUCAGACCCUUAUAACCUGAUUUGGUUAAUACCAACGUAGGAAAGUAGUUAUUAACUAUUCGUCAUUGAGAUGUCUUGGUCUAACUACUUUCUUCGCUGGGAAGUAGUU",
+        "GGGAACGACUCGAGUAGAGUCGAAAAAUCUUCAUAACUGAAUACAAAGGUAGAAGAUUAUUCAGUUAUAUUAAAAAGGAUGUCUUCGGGCAUUCAAAAGAAACAACAACAACAAC"
     ];
     const testStructures = [
         "......",
         "(((((......)))))",
         "((((((((...........)).))))))",
         "(((.((((((((..((((.(((((....)).)))..))))..))))((((...))))))))...)))",
-        ".(((((((((.((((....))))....((((....))))..))))..(((((......)))))...(((.((.(((((((((((((...((((..((((.....))))...)))).))))))))))))))).)))..))))).."
+        ".(((((((((.((((....))))....((((....))))..))))..(((((......)))))...(((.((.(((((((((((((...((((..((((.....))))...)))).))))))))))))))).)))..)))))..",
+        ".....((((((.....))))))....(((((({{{{{{{{{{{........))))))}}}}}}}}}}}........(((((((....)))))))....................."
     ];
 
     return expect(CreateFolder(EternaFoldThreshknot)
@@ -29,7 +32,8 @@ test(`EternaFoldThreshknot:folds_structures`, () => {
             if (folder === null) return;
 
             testSequences.map((sequence, index) => {
-                const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct());
+                const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct(), null, true);
+                // console.log(foldedStructure?.getParenthesis(null, true))
                 expect(foldedStructure?.getParenthesis(null, true)).toBe(testStructures[index])
             })
         })).resolves.toBeUndefined();
@@ -43,13 +47,68 @@ test(`EternaFoldThreshknot:predicts_pseudoknots`, () => {
         "GGGAACGACUCGAGUAGAGUCGAAAAGCAUCGAGCUAGCAAGAGCAUGUUGGAAGCUAGCAACCUUCAUGCCGAUGCAAUCCCAGGCUAAUGCCAACGACUCUACUCGAGUCGACAGCUUUGUUUCGACAAAGCAAAAGAAACAACAACAACAAC"
     ];
 
+    const testStructures = [
+        "((((((((((((({{{{{{)))...((((((((((((((((}}}}}}))).)))))))))))))))))))))))..(((((((....))))))).....................",
+        ".....((((((.....)))))).............(((((.................{{{{......)))))}}}}(((((((....))))))).....................",
+        ".....((((((.....))))))....(((((........)))))..((((.....((((..((....................{{{{{{{..))..))))..))))}}}}}}}...(((((((....))))))).....................",
+        ".....(((((((((((((((((....(((((({{{(({{{...{{{{{..{{....))....}}..}}}}})).}}}........}}}.))))...)))))))))))))))))...(((((((....)))))))....................."
+    ];
+
     return expect(CreateFolder(EternaFoldThreshknot)
         .then((folder) => {
             if (folder === null) return;
 
-            testSequences.map((sequence) => {
-                const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct());
-                expect(foldedStructure?.getParenthesis(null, true)).toContain("{")
+            testSequences.map((sequence, index) => {
+                const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct(), null, true);
+                // console.log(foldedStructure?.getParenthesis(null, true))
+                expect(foldedStructure?.getParenthesis(null, true)).toBe(testStructures[index])
             })
         })).resolves.toBeUndefined();
 });
+
+test('EternaFoldThreshknot:matches_Eternafold_w/o_pseudoknots', () => {    
+    
+    const testSequences = [
+        "GGGAACGACUCGAGUAGAGUCGAAAAGAAUACGUUGGGAAACGCCUUCGAACGAUCCCACGCGAUCGUCUGUUCGAGGUAAUUUUCGAAUUACCAAAAGAAACAACAACAACAAC",
+        "GGGAACGACUCGAGUAGAGUCGAAAAGAAAGCGUGCGGACGAACGUGCGUGCGUGCGAACGGACGUGCGUAAGCAACGUUAUAUUCGUAUAACGAAAAGAAACAACAACAACAAC"
+    ];
+
+    return expect(CreateFolder(EternaFoldThreshknot)
+        .then((folderTK) => {
+            CreateFolder(EternaFold).then((folderEF) => {
+                if (folderTK === null) return;
+                if (folderEF === null) return;
+
+                testSequences.map((sequence) => {
+                    const foldedStructureTK =  folderTK.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct(), null, false);
+                    const foldedStructureEF =  folderEF.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct());
+                    const dbnTK = foldedStructureTK?.getParenthesis(null, false);
+                    const dbnEF = foldedStructureEF?.getParenthesis(null, false);
+                    expect(dbnTK).toBe(dbnEF)
+                })
+            })
+        })).resolves.toBeUndefined();
+})  
+
+test('EternaFoldThreshknot:removes_single_pair_helices', () => {
+// This sequence is predicted to be (((.(.((....)).).))) by Eternafold
+// This test checks that Threshknot removes the single pair helix
+    
+const testSequences = [
+    "CGGAGACCAAAAGGACACCG"
+];
+
+const testStructures = [
+    "(((...((....))...)))"
+];
+
+ return expect(CreateFolder(EternaFoldThreshknot)
+    .then((folder) => {
+        if (folder === null) return;
+
+        testSequences.map((sequence, index) => {
+            const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct(), null, true);
+            expect(foldedStructure?.getParenthesis(null, true)).toBe(testStructures[index])
+        })
+    })).resolves.toBeUndefined();
+})

--- a/src/eterna/folding/__tests__/EternafoldThreshknot.test.ts
+++ b/src/eterna/folding/__tests__/EternafoldThreshknot.test.ts
@@ -1,0 +1,55 @@
+import Folder from '../Folder';
+// import './jest-matcher-deep-close-to';
+import SecStruct from 'eterna/rnatypes/SecStruct';
+import Sequence from 'eterna/rnatypes/Sequence';
+import EternaFoldThreshknot from 'eterna/folding/EternafoldThreshknot';
+
+function CreateFolder(type: any): Promise<Folder | null> {
+    return type.create();
+}
+
+test(`EternaFoldThreshknot:folds_structures`, () => {
+    const testSequences = [
+        "AAAAAA",
+        "AUAUCAAAAAAGAUAU", // Simple Hairpin
+        "GGGGGGGGAAAACGGAAAGCCACCCCCC",
+        "CCCAGGUCGUAGAACUAAAGCGCCAAAAGGACGCAAUUAGAACUACAUGCAUAGCAUGACCAAAGGG",
+        "CCUACUAGGGGAGCCAAAAGGCUGAGAUGAAUGUAUUCAGACCCUUAUAACCUGAUUUGGUUAAUACCAACGUAGGAAAGUAGUUAUUAACUAUUCGUCAUUGAGAUGUCUUGGUCUAACUACUUUCUUCGCUGGGAAGUAGUU",
+    ];
+    const testStructures = [
+        "......",
+        "(((((......)))))",
+        "((((((((...........)).))))))",
+        "(((.((((((((..((((.(((((....)).)))..))))..))))((((...))))))))...)))",
+        ".(((((((((.((((....))))....((((....))))..))))..(((((......)))))...(((.((.(((((((((((((...((((..((((.....))))...)))).))))))))))))))).)))..))))).."
+    ];
+
+    return expect(CreateFolder(EternaFoldThreshknot)
+        .then((folder) => {
+            if (folder === null) return;
+
+            testSequences.map((sequence, index) => {
+                const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct());
+                expect(foldedStructure?.getParenthesis(null, true)).toBe(testStructures[index])
+            })
+        })).resolves.toBeUndefined();
+});
+
+test(`EternaFoldThreshknot:predicts_pseudoknots`, () => {
+    const testSequences = [
+        "GGGAACGACUCGAGUAGAGUCGAAAACUCUGGUCUCUACGACUCUACUCGAUAGAGGCUGGAGUAGUCGUUCCCGACGACAUGUUCGCGUGUCGAAAAGAAACAACAACAACAAC",
+        "GGGAACGACUCGAGUAGAGUCGAAAAUGGUGGAGGAGGUGGAAAGCUCGGCAUUAAAGGGAUAAAAACAUCUUCCCGUUCGGGUUCGCCCGAACAAAAGAAACAACAACAACAAC",
+        "GGGAACGACUCGAGUAGAGUCGAAAACAUGCAGAAAUAAGCAUGGUGCUCAAAAAGUAGAACGAAAGAUCAAAAAUUGAGAAAAUGAUCCAACGAACUACAAGAGCGGAUCAUAAACGCGAUCUUCGGAUCGCGAAAAGAAACAACAACAACAAC",
+        "GGGAACGACUCGAGUAGAGUCGAAAAGCAUCGAGCUAGCAAGAGCAUGUUGGAAGCUAGCAACCUUCAUGCCGAUGCAAUCCCAGGCUAAUGCCAACGACUCUACUCGAGUCGACAGCUUUGUUUCGACAAAGCAAAAGAAACAACAACAACAAC"
+    ];
+
+    return expect(CreateFolder(EternaFoldThreshknot)
+        .then((folder) => {
+            if (folder === null) return;
+
+            testSequences.map((sequence) => {
+                const foldedStructure =  folder.foldSequence(Sequence.fromSequenceString(sequence), new SecStruct());
+                expect(foldedStructure?.getParenthesis(null, true)).toContain("{")
+            })
+        })).resolves.toBeUndefined();
+});

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -26,6 +26,7 @@ import LinearFoldV from 'eterna/folding/LinearFoldV';
 import LinearFoldC from 'eterna/folding/LinearFoldC';
 import LinearFoldE from 'eterna/folding/LinearFoldE';
 import EternaFold from 'eterna/folding/Eternafold';
+import EternaFoldThreshknot from 'eterna/folding/EternafoldThreshknot';
 import ConstraintBar from 'eterna/constraints/ConstraintBar';
 import Utility from 'eterna/util/Utility';
 import ShapeConstraint from 'eterna/constraints/constraints/ShapeConstraint';
@@ -291,7 +292,11 @@ export default class PuzzleEditMode extends GameMode {
         this._targetButton = targetButton;
 
         this._folderSwitcher = this._modeBar.addFolderSwitcher((folder) => {
-            if (this._numTargets > 1 && !folder.canFoldWithBindingSite) return false;
+            if (
+                this._numTargets > 1
+                && !folder.canFoldWithBindingSite
+                && folder.name !== EternaFoldThreshknot.NAME
+            ) return false;
             return true;
         });
         this._folderSwitcher.selectedFolder.connectNotify((folder) => {


### PR DESCRIPTION
## Summary
This commit adds a new folding engine that uses Eternafold for the initial base pair probability generation, then uses the Threshknot heuristic (https://arxiv.org/abs/1912.12796) to evaluate the bpp matrix and generate pairs (including pseudoknots). This engine is being implemented for use in the Pseudoknot project, with the goal of greatly speeding up computation time compared to NuPACK+PK.

## Implementation Notes
These heuristic algorithms (Threshknot, Hungarian, etc) take the base pair probability matrix output of a folding engine and use it to select base pairs and generate a structure. As such, they can be applied to any folding engine that can output a base pair probability matrix. We currently have no way to add a post-fold processing step into the folding pipeline, so the simplest approach was to create a new folding engine, `EternaFoldThreshknot`, that uses the Threshknot algorithm in it's `foldSeqImpl` method. Some notes on this Threshknot implementation:

- There is a filter parameter `theta` that accepts or rejects base pair probabilities as significant. The original paper uses a `theta` value of 0.3. We uses a value of 0.15 here, which achieves similar correlation coefficients with the PK50 dataset, while increasing the likelihood of pseudoknot prediction roughly 4x.
- The original paper gives no details on how the algorithm should handle equal base pair probabilities (e.g. [1,4] and [1,7] both have a pair probability of 0.5). This implementation chooses whichever comes first in the bpp matrix.
- There is a filter step to remove duplicate base pairs should the algorithm generate them. I've not run into this situation, but it was in the `arnie` implementation.

## Testing
There is an EternafoldThreshknot test file that checks the engine folds appropriately, and that it can generate pseudoknots. I also ran the app locally on the PK100 test puzzle and demonstrated the improved folding speed.
