### PR TITLE
Fix specs with pseudoknots and melt plot

### DIFF
--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -456,7 +456,7 @@ export default class UndoBlock {
     public getPairs(temp: number = 37, pseudoknots: boolean = false): SecStruct {
         const pairsArray = this._pairsArray.get(pseudoknots);
         Assert.assertIsDefined(pairsArray);
-        return new SecStruct(pairsArray[temp]?.pairs) ?? null;
+        return new SecStruct(pairsArray[temp]?.pairs);
     }
 
     public getParam(
@@ -656,7 +656,7 @@ export default class UndoBlock {
         }
 
         for (let ii = 37; ii < 100; ii += 10) {
-            if (this.getPairs(ii) == null) {
+            if (this.getPairs(ii, pseudoknots).length === 0) {
                 const pairs: SecStruct | null = folder.foldSequence(this.sequence, null, null, pseudoknots, ii);
                 Assert.assertIsDefined(pairs);
                 this.setPairs(pairs, ii, pseudoknots);
@@ -665,7 +665,7 @@ export default class UndoBlock {
             if (this.getParam(UndoBlockParam.DOTPLOT, ii, pseudoknots) == null) {
                 const dotTempArray: DotPlot | null = folder.getDotPlot(
                     this.sequence,
-                    this.getPairs(ii),
+                    this.getPairs(ii, pseudoknots),
                     ii,
                     pseudoknots
                 );

--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -630,7 +630,8 @@ export default class UndoBlock {
             throw new Error(`Critical error: can't create a ${this._folderName} folder instance by name`);
         }
 
-        if (this.getParam(UndoBlockParam.DOTPLOT, 37, pseudoknots) === undefined) {
+        const currDotPlot = this.getParam(UndoBlockParam.DOTPLOT, 37, pseudoknots);
+        if (currDotPlot === undefined) {
             const dotArray: DotPlot | null = folder.getDotPlot(
                 this.sequence, this.getPairs(37), 37, pseudoknots
             );
@@ -650,6 +651,8 @@ export default class UndoBlock {
                 pseudoknots
             );
             this._dotPlotData = dotArray;
+        } else if (Array.isArray(currDotPlot)) {
+            this._dotPlotData = new DotPlot(currDotPlot);
         }
 
         for (let ii = 37; ii < 100; ii += 10) {
@@ -659,7 +662,7 @@ export default class UndoBlock {
                 this.setPairs(pairs, ii, pseudoknots);
             }
 
-            if (this.getParam(UndoBlockParam.DOTPLOT, ii) == null) {
+            if (this.getParam(UndoBlockParam.DOTPLOT, ii, pseudoknots) == null) {
                 const dotTempArray: DotPlot | null = folder.getDotPlot(
                     this.sequence,
                     this.getPairs(ii),
@@ -686,7 +689,7 @@ export default class UndoBlock {
         const maxPairScores: number[] = [];
 
         for (let ii = 37; ii < 100; ii += 10) {
-            if (this.getParam(UndoBlockParam.PROB_SCORE, ii)) {
+            if (this.getParam(UndoBlockParam.PROB_SCORE, ii, pseudoknots)) {
                 pairScores.push(1 - (this.getParam(UndoBlockParam.PAIR_SCORE, ii, pseudoknots) as number));
                 maxPairScores.push(1.0);
                 continue;

--- a/src/eterna/constraints/constraints/TargetExpectedAccuracyConstraint.ts
+++ b/src/eterna/constraints/constraints/TargetExpectedAccuracyConstraint.ts
@@ -32,7 +32,7 @@ export default class TargetExpectedAccuracyConstraint extends Constraint<TargetE
         // zero.
         // AMW: no
         if (undoBlock.getParam(UndoBlockParam.TARGET_EXPECTED_ACCURACY, 37, pseudoknots) === undefined) {
-            undoBlock.updateMeltingPointAndDotPlot(false);
+            undoBlock.updateMeltingPointAndDotPlot(pseudoknots);
         }
 
         // For some reason the null-coalescing operator ?? is not supported here.

--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -538,13 +538,14 @@ export default class FeedbackViewMode extends GameMode {
         }
 
         const undoBlock = this._undoBlocks[this._curTargetIndex];
-        const numAU: number = undoBlock.getParam(UndoBlockParam.AU, 37) as number;
-        const numGU: number = undoBlock.getParam(UndoBlockParam.GU, 37) as number;
-        const numGC: number = undoBlock.getParam(UndoBlockParam.GC, 37) as number;
+        const pseudoknots = undoBlock.targetConditions?.type === 'pseudoknot';
+        const numAU: number = undoBlock.getParam(UndoBlockParam.AU, 37, pseudoknots) as number;
+        const numGU: number = undoBlock.getParam(UndoBlockParam.GU, 37, pseudoknots) as number;
+        const numGC: number = undoBlock.getParam(UndoBlockParam.GC, 37, pseudoknots) as number;
         this._toolbar.palette.setPairCounts(numAU, numGU, numGC);
 
         if (this._specBox) {
-            undoBlock.updateMeltingPointAndDotPlot();
+            undoBlock.updateMeltingPointAndDotPlot(pseudoknots);
             this._specBox?.setSpec(undoBlock);
         }
 

--- a/src/eterna/ui/SpecBoxDialog.ts
+++ b/src/eterna/ui/SpecBoxDialog.ts
@@ -133,23 +133,24 @@ export default class SpecBoxDialog extends WindowDialog<void> {
         });
         EPars.addLetterStyles(statString);
 
+        const pseudoknots = this._dataBlock.targetConditions?.type === 'pseudoknot';
         statString
             .append(`${EPars.getColoredLetter('A')}-${EPars.getColoredLetter('U')} pairs : `, 'bold')
-            .append(`${this._dataBlock.getParam(UndoBlockParam.AU, TEMPERATURE)}   `)
+            .append(`${this._dataBlock.getParam(UndoBlockParam.AU, TEMPERATURE, pseudoknots)}   `)
             .append(`${EPars.getColoredLetter('G')}-${EPars.getColoredLetter('C')} pairs : `, 'bold')
-            .append(`${this._dataBlock.getParam(UndoBlockParam.GC, TEMPERATURE)}   `)
+            .append(`${this._dataBlock.getParam(UndoBlockParam.GC, TEMPERATURE, pseudoknots)}   `)
             .append(`${EPars.getColoredLetter('G')}-${EPars.getColoredLetter('U')} pairs : `, 'bold')
-            .append(`${this._dataBlock.getParam(UndoBlockParam.GU, TEMPERATURE)}\n`)
+            .append(`${this._dataBlock.getParam(UndoBlockParam.GU, TEMPERATURE, pseudoknots)}\n`)
             .append('Free energy : ', 'bold')
-            .append(`${Number(this._dataBlock.getParam(UndoBlockParam.FE, TEMPERATURE) as number / 100).toFixed(1)} kcal\t\t`)
+            .append(`${Number(this._dataBlock.getParam(UndoBlockParam.FE, TEMPERATURE, pseudoknots) as number / 100).toFixed(1)} kcal\t\t`)
             .append('Melting point : ', 'bold')
-            .append(`${this._dataBlock.getParam(UndoBlockParam.MELTING_POINT, TEMPERATURE)}°C\n`)
+            .append(`${this._dataBlock.getParam(UndoBlockParam.MELTING_POINT, TEMPERATURE, pseudoknots)}°C\n`)
             .append('Mean P-unpaired : ', 'bold')
-            .append(`${Number(this._dataBlock.getParam(UndoBlockParam.MEANPUNP, TEMPERATURE)).toFixed(3)}\t\t`)
+            .append(`${Number(this._dataBlock.getParam(UndoBlockParam.MEANPUNP, TEMPERATURE, pseudoknots)).toFixed(3)}\t\t`)
             .append('Branchiness : ', 'bold')
-            .append(`${Number(this._dataBlock.getParam(UndoBlockParam.BRANCHINESS, TEMPERATURE)).toFixed(1)}\n`)
+            .append(`${Number(this._dataBlock.getParam(UndoBlockParam.BRANCHINESS, TEMPERATURE, pseudoknots)).toFixed(1)}\n`)
             .append('Target exp acc : ', 'bold')
-            .append(`${(this._dataBlock.getParam(UndoBlockParam.TARGET_EXPECTED_ACCURACY, 37) as number)?.toFixed(3) ?? 'Unavailable'}`);
+            .append(`${(this._dataBlock.getParam(UndoBlockParam.TARGET_EXPECTED_ACCURACY, TEMPERATURE, pseudoknots) as number)?.toFixed(3) ?? 'Unavailable'}`);
 
         statString.apply(this._statText);
 


### PR DESCRIPTION
## Summary
Previously, pseudoknotted structures were showing "empty" specs in the specbox and when solutions were uploaded. Additionally, The melt plot was only (correctly) calculating the % unpaired at 37 degrees, instead of at each 10-degree interval

## Implementation Notes
The first issue is due to stats inconsistently being stored/retrieved as having pknots enabled or not. The latter issue is due to getPairs returning an empty structure when pairs are not available where it was being checked against being null (due to a refactoring)