### PR TITLE
Custom target structure improvements

### DIFF
--- a/src/eterna/EPars.ts
+++ b/src/eterna/EPars.ts
@@ -350,8 +350,22 @@ export default class EPars {
             }
         }
 
+        // order 3 PKs
+        const pkStack3: number[] = [];
+        for (let jj = 0; jj < parenthesis.length; jj++) {
+            if (parenthesis.charAt(jj) === '<') {
+                pkStack3.push(jj);
+            } else if (parenthesis.charAt(jj) === '>') {
+                if (pkStack3.length === 0) {
+                    return 'Unbalanced parenthesis notation <>';
+                }
+
+                pkStack3.pop();
+            }
+        }
+
         for (let jj = 0; jj < parenthesis.length; ++jj) {
-            if (!'.()[]{}'.includes(parenthesis.charAt(jj))) {
+            if (!'.()[]{}<>'.includes(parenthesis.charAt(jj))) {
                 return `Unrecognized character ${parenthesis.charAt(jj)}`;
             }
         }
@@ -364,12 +378,26 @@ export default class EPars {
             return null;
         }
 
-        let index: number = parenthesis.indexOf('(.)');
+        let index = parenthesis.indexOf('()');
+        if (index === -1) index = parenthesis.indexOf('[]');
+        if (index === -1) index = parenthesis.indexOf('{}');
+        if (index === -1) index = parenthesis.indexOf('<>');
+        if (index >= 0) {
+            return `There is a length 0 hairpin loop which is impossible at base ${index + 2}`;
+        }
+
+        index = parenthesis.indexOf('(.)');
+        if (index === -1) index = parenthesis.indexOf('[.]');
+        if (index === -1) index = parenthesis.indexOf('{.}');
+        if (index === -1) index = parenthesis.indexOf('<.>');
         if (index >= 0) {
             return `There is a length 1 hairpin loop which is impossible at base ${index + 2}`;
         }
 
         index = parenthesis.indexOf('(..)');
+        if (index === -1) index = parenthesis.indexOf('[..]');
+        if (index === -1) index = parenthesis.indexOf('{..}');
+        if (index === -1) index = parenthesis.indexOf('<..>');
 
         if (index >= 0) {
             return `There is a length 2 hairpin loop which is impossible at base ${index + 2}`;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1771,6 +1771,11 @@ export default class PoseEditMode extends GameMode {
 
             this.poseEditByTarget(this._isPipMode ? poseIdx : 0);
         }));
+        this.regs?.add(pasteDialog.resetClicked.connect(() => {
+            const targetIndex = this._isPipMode ? poseIdx : this._curTargetIndex;
+            this._targetPairs[targetIndex] = SecStruct.fromParens(this._puzzle.getSecstruct(targetIndex));
+            this.poseEditByTarget(this._isPipMode ? poseIdx : 0);
+        }));
     }
 
     private openDesignBrowserForOurPuzzle(): void {

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1773,6 +1773,7 @@ export default class PoseEditMode extends GameMode {
         }));
         this.regs?.add(pasteDialog.resetClicked.connect(() => {
             const targetIndex = this._isPipMode ? poseIdx : this._curTargetIndex;
+            this._targetOligosOrder[targetIndex] = undefined;
             this._targetPairs[targetIndex] = SecStruct.fromParens(this._puzzle.getSecstruct(targetIndex));
             this.poseEditByTarget(this._isPipMode ? poseIdx : 0);
         }));

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -77,6 +77,7 @@ import KeyedCollection from 'eterna/util/KeyedCollection';
 import {FederatedPointerEvent} from '@pixi/events';
 import NuPACK from 'eterna/folding/NuPACK';
 import PasteStructureDialog from 'eterna/ui/PasteStructureDialog';
+import ConfirmTargetDialog from 'eterna/ui/ConfirmTargetDialog';
 import GameMode from '../GameMode';
 import SubmittingDialog from './SubmittingDialog';
 import SubmitPoseDialog from './SubmitPoseDialog';
@@ -2158,25 +2159,58 @@ export default class PoseEditMode extends GameMode {
                 libraryNT: this._poses[0].librarySelections ?? []
             }, solToSubmit);
         } else {
-            const NOT_SATISFIED_PROMPT = 'Puzzle constraints are not satisfied.\n\n'
-                + 'You can still submit the sequence, but please note that there is a risk of not getting '
-                + 'synthesized properly';
-
-            if (!this.checkConstraints()) {
-                // If we pass constraints when taking into account soft constraints, just prompt
-                if (this.checkConstraints(this._puzzle.isSoftConstraint || Eterna.DEV_MODE)) {
-                    this.showConfirmDialog(NOT_SATISFIED_PROMPT).closed
-                        .then((confirmed) => {
-                            if (confirmed) {
-                                this.promptForExperimentalPuzzleSubmission();
+            const pipeline = [
+                () => {
+                    if (!this.checkConstraints()) {
+                        // If we pass constraints when taking into account soft constraints, just prompt
+                        if (this.checkConstraints(this._puzzle.isSoftConstraint || Eterna.DEV_MODE)) {
+                            const NOT_SATISFIED_PROMPT = 'Puzzle constraints are not satisfied.\n\n'
+                            + 'You can still submit the sequence, but please note that there is a risk of not getting '
+                            + 'synthesized properly';
+                            this.showConfirmDialog(NOT_SATISFIED_PROMPT).closed
+                                .then((confirmed) => {
+                                    if (confirmed) {
+                                        const next = pipeline.shift();
+                                        if (next) next();
+                                    }
+                                });
+                        } else {
+                            this.showNotification("You didn't satisfy all requirements!");
+                        }
+                    } else {
+                        const next = pipeline.shift();
+                        if (next) next();
+                    }
+                },
+                () => {
+                    if (!this.checkValidCustomPairs()) {
+                        const dialog = this.showDialog(new ConfirmTargetDialog());
+                        dialog.closed.then((confirmed) => {
+                            if (confirmed === 'reset') {
+                                for (let i = 0; i < this._targetPairs.length; i++) {
+                                    this._targetOligosOrder[i] = undefined;
+                                    this._targetPairs[i] = SecStruct.fromParens(this._puzzle.getSecstruct(i));
+                                }
+                                this.poseEditByTarget(this._isPipMode ? this._curTargetIndex : 0);
+                                const next = pipeline.shift();
+                                if (next) next();
+                            } else if (confirmed === 'submit') {
+                                const next = pipeline.shift();
+                                if (next) next();
                             }
                         });
-                } else {
-                    this.showNotification("You didn't satisfy all requirements!");
+                    } else {
+                        const next = pipeline.shift();
+                        if (next) next();
+                    }
+                },
+                () => {
+                    this.promptForExperimentalPuzzleSubmission();
                 }
-            } else {
-                this.promptForExperimentalPuzzleSubmission();
-            }
+            ];
+
+            const next = pipeline.shift();
+            if (next) next();
         }
     }
 
@@ -2862,6 +2896,29 @@ export default class PoseEditMode extends GameMode {
             targetConditions: this._targetConditions,
             puzzle: this._puzzle
         }, soft);
+    }
+
+    private checkValidCustomPairs(): boolean {
+        for (const ublk of this.getCurrentUndoBlocks()) {
+            const constraints = ublk.targetAlignedStructureConstraints;
+            if (constraints) {
+                const targetSeq = EPars.constructFullSequence(
+                    ublk.sequence,
+                    ublk.targetOligo,
+                    ublk.targetOligos,
+                    ublk.targetOligoOrder,
+                    ublk.oligoMode
+                );
+                const targetStruct = ublk.targetPairs;
+                const satisfiedStruct = ublk.targetPairs.getSatisfiedPairs(targetSeq);
+                // We only want to check unconstrained bases that are in a pair in the target structure
+                const customConstraints = constraints.map(
+                    (constrained, idx) => !constrained && targetStruct.isPaired(idx)
+                );
+                if (!EPars.arePairsSame(targetStruct, satisfiedStruct, customConstraints)) return false;
+            }
+        }
+        return true;
     }
 
     private updateScore(): void {
@@ -3619,6 +3676,10 @@ export default class PoseEditMode extends GameMode {
         } else {
             return this._seqStacks[this._stackLevel][targetIndex];
         }
+    }
+
+    protected getCurrentUndoBlocks(): UndoBlock[] {
+        return this._seqStacks[this._stackLevel];
     }
 
     private setPosesWithUndoBlock(ii: number, undoBlock: UndoBlock): void {

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -2165,8 +2165,8 @@ export default class PoseEditMode extends GameMode {
                         // If we pass constraints when taking into account soft constraints, just prompt
                         if (this.checkConstraints(this._puzzle.isSoftConstraint || Eterna.DEV_MODE)) {
                             const NOT_SATISFIED_PROMPT = 'Puzzle constraints are not satisfied.\n\n'
-                            + 'You can still submit the sequence, but please note that there is a risk of not getting '
-                            + 'synthesized properly';
+                            + 'You can still submit the sequence, but please note that there is a risk of the design '
+                            + 'not getting synthesized properly';
                             this.showConfirmDialog(NOT_SATISFIED_PROMPT).closed
                                 .then((confirmed) => {
                                     if (confirmed) {

--- a/src/eterna/ui/ConfirmTargetDialog.ts
+++ b/src/eterna/ui/ConfirmTargetDialog.ts
@@ -15,9 +15,11 @@ export default class ConfirmTargetDialog extends WindowDialog<'cancel' | 'reset'
         this._window.content.addChild(content);
 
         const PROMPT = 'This design has a custom target structure that will be uploaded along with your design, '
-         + 'but there are paired bases in the target structure with base types that are not valid pairs (AU/UG/GC). '
-         + 'Do you want to cancel submitting and make further modifications, reset the target structure to the '
-         + 'puzzle\'s default, or continue submitting this design anyways?';
+         + 'but there are paired bases in the target structure with base types that are not valid pairs (AU/UG/GC).\n\n'
+         + 'You can do one of the following:\n'
+         + '• Cancel submitting and make further modifications\n'
+         + '• Reset the target structure to the puzzle\'s default\n'
+         + '• Continue submitting this design anyways';
         const text = Fonts.std(PROMPT, 15).color(0xC0DCE7).wordWrap(true, 300).build();
         content.addChild(text);
 

--- a/src/eterna/ui/ConfirmTargetDialog.ts
+++ b/src/eterna/ui/ConfirmTargetDialog.ts
@@ -1,0 +1,45 @@
+import Fonts from 'eterna/util/Fonts';
+import {AlphaTask, HLayoutContainer, VLayoutContainer} from 'flashbang';
+import GameButton from './GameButton';
+import WindowDialog from './WindowDialog';
+
+export default class ConfirmTargetDialog extends WindowDialog<'cancel' | 'reset' | 'submit'> {
+    constructor() {
+        super({title: 'Are you sure?', modal: true});
+    }
+
+    protected added() {
+        super.added();
+
+        const content = new VLayoutContainer(20);
+        this._window.content.addChild(content);
+
+        const PROMPT = 'This design has a custom target structure that will be uploaded along with your design, '
+         + 'but there are paired bases in the target structure with base types that are not valid pairs (AU/UG/GC). '
+         + 'Do you want to cancel submitting and make further modifications, reset the target structure to the '
+         + 'puzzle\'s default, or continue submitting this design anyways?';
+        const text = Fonts.std(PROMPT, 15).color(0xC0DCE7).wordWrap(true, 300).build();
+        content.addChild(text);
+
+        const buttonLayout = new HLayoutContainer(12);
+        content.addChild(buttonLayout);
+
+        const cancelButton = new GameButton('secondary').label('Cancel', 14);
+        this.addObject(cancelButton, buttonLayout);
+        cancelButton.clicked.connect(() => this.close('cancel'));
+
+        const resetButton = new GameButton('secondary').label('Reset', 14);
+        this.addObject(resetButton, buttonLayout);
+        resetButton.clicked.connect(() => this.close('reset'));
+
+        const submitButton = new GameButton('secondary').label('Submit', 14);
+        this.addObject(submitButton, buttonLayout);
+        submitButton.clicked.connect(() => this.close('submit'));
+
+        content.layout();
+        this._window.layout();
+
+        this._window.display.alpha = 0;
+        this._window.addObject(new AlphaTask(1, 0.3));
+    }
+}

--- a/src/eterna/ui/ConfirmTargetDialog.ts
+++ b/src/eterna/ui/ConfirmTargetDialog.ts
@@ -17,7 +17,7 @@ export default class ConfirmTargetDialog extends WindowDialog<'cancel' | 'reset'
         const PROMPT = 'This design has a custom target structure that will be uploaded along with your design, '
          + 'but there are paired bases in the target structure with base types that are not valid pairs (AU/UG/GC).\n\n'
          + 'You can do one of the following:\n'
-         + '• Cancel submitting and make further modifications\n'
+         + '• Cancel submission and make further modifications\n'
          + '• Reset the target structure to the puzzle\'s default\n'
          + '• Continue submitting this design anyways';
         const text = Fonts.std(PROMPT, 15).color(0xC0DCE7).wordWrap(true, 300).build();

--- a/src/eterna/ui/PasteStructureDialog.ts
+++ b/src/eterna/ui/PasteStructureDialog.ts
@@ -3,6 +3,7 @@ import {Signal} from 'signals';
 import {Text} from 'pixi.js';
 import Fonts from 'eterna/util/Fonts';
 import SecStruct from 'eterna/rnatypes/SecStruct';
+import EPars from 'eterna/EPars';
 import WindowDialog from './WindowDialog';
 import TextInputGrid from './TextInputGrid';
 import GameButton from './GameButton';
@@ -67,12 +68,12 @@ export default class PasteStructureDialog extends WindowDialog<void> {
 
         const startAt = startAtStr ? parseInt(startAtStr, 10) : 1;
 
-        const validStruct = /^[.()[\]{}<>]+$/.test(structure);
+        const validationError = EPars.validateParenthesis(structure, false);
         if (structure.length === 0) {
             this._errorText.text = 'Please enter a structure';
             this._errorText.visible = true;
-        } else if (!validStruct) {
-            this._errorText.text = 'You can only use the following characters: .()[]{}<>';
+        } else if (validationError) {
+            this._errorText.text = validationError;
             this._errorText.visible = true;
         } else if (Number.isNaN(startAt)) {
             this._errorText.text = 'Please enter a valid number for the starting base';

--- a/src/eterna/ui/PasteStructureDialog.ts
+++ b/src/eterna/ui/PasteStructureDialog.ts
@@ -1,4 +1,4 @@
-import {VLayoutContainer} from 'flashbang';
+import {HLayoutContainer, VLayoutContainer} from 'flashbang';
 import {Signal} from 'signals';
 import {Text} from 'pixi.js';
 import Fonts from 'eterna/util/Fonts';
@@ -15,6 +15,7 @@ interface PasteResult {
 
 export default class PasteStructureDialog extends WindowDialog<void> {
     public readonly applyClicked: Signal<PasteResult> = new Signal();
+    public readonly resetClicked: Signal<void> = new Signal();
 
     constructor(pseudoknots: boolean) {
         super({title: 'Paste a structure'});
@@ -40,9 +41,14 @@ export default class PasteStructureDialog extends WindowDialog<void> {
         this._startAtField = inputGrid.addField('Starting base', 50);
         this.addObject(inputGrid, this._content);
 
+        const buttonLayout = new HLayoutContainer(6);
+        this._content.addChild(buttonLayout);
+        const resetButton = new GameButton('secondary').label('Reset', 14);
         const applyButton = new GameButton().label('Apply', 14);
-        this.addObject(applyButton, this._content);
+        this.addObject(resetButton, buttonLayout);
+        this.addObject(applyButton, buttonLayout);
 
+        resetButton.clicked.connect(() => this.resetClicked.emit());
         applyButton.clicked.connect(() => this.onApply(this._structureField.text, this._startAtField.text));
         this.regs.add(this._structureField.keyPressed.connect((key) => {
             if (key === 'Enter') this.onApply(this._structureField.text, this._startAtField.text);

--- a/src/eterna/ui/PasteStructureDialog.ts
+++ b/src/eterna/ui/PasteStructureDialog.ts
@@ -44,7 +44,7 @@ export default class PasteStructureDialog extends WindowDialog<void> {
 
         const buttonLayout = new HLayoutContainer(6);
         this._content.addChild(buttonLayout);
-        const resetButton = new GameButton('secondary').label('Reset', 14);
+        const resetButton = new GameButton('secondary').label('Reset', 14).tooltip('Reset to Default Structure');
         const applyButton = new GameButton().label('Apply', 14);
         this.addObject(resetButton, buttonLayout);
         this.addObject(applyButton, buttonLayout);


### PR DESCRIPTION
## Summary
* The paste target structure dialog now has a button that will reset the target structure to the puzzle's default
* When submitting an experimental puzzle, if you have a custom target structure where there are pairs in the custom region which are invalid, confirm that the custom target is intended (with an option to reset).
* This PR also implements improved validation for pasted target structures

## Implementation Notes
* The SHAPE and ANTISHAPE constraints contained custom logic to handle alternate oligo ordering when referencing the structure constraints and native structure. These have been moved into undoblock for reusability. 
* On experimental puzzle submission, we now create a "pipeline" of validation steps. This allows for moving from one step to the next easily when either validation passes or after the user ignores validation errors, without code duplication.

## Testing
On the PK100 puzzle
* Used reset button in paste target dialog with custom target and original target
* Attempted to submit with invalid custom target and invalid constraints, verified cancel/reset/submit
* Attempted to submit with valid custom target and invalid constraints
* Attempted to submit with invalid custom target and valid constraints, verified cancel/reset/submit
* Attempted to submit with valid custom target and valid constraints