### PR TITLE
Make smallest base lock graphic look rounder

### DIFF
--- a/src/eterna/pose2D/BaseAssets.ts
+++ b/src/eterna/pose2D/BaseAssets.ts
@@ -398,7 +398,7 @@ export default class BaseAssets {
         const lockTexSm = getLockTexture(texSizeSm);
 
         const tinyLock = new Graphics().beginFill(0x050505, 0.8).drawCircle(0, 0, 6);
-        tinyLock.filters = [new BlurFilter(1, 40), new FXAAFilter()];
+        tinyLock.filters = [new BlurFilter(2, 4), new FXAAFilter()];
         const tinyLockTex = TextureUtil.renderToTexture(tinyLock);
 
         const maxSize = BaseTextures.BODY_SIZE - 6;

--- a/src/eterna/pose2D/BaseAssets.ts
+++ b/src/eterna/pose2D/BaseAssets.ts
@@ -397,7 +397,8 @@ export default class BaseAssets {
         const texSizeSm = 2 ** 3;
         const lockTexSm = getLockTexture(texSizeSm);
 
-        const tinyLock = new Graphics().beginFill(0x050505, 0.8).drawCircle(0, 0, 1.5);
+        const tinyLock = new Graphics().beginFill(0x050505, 0.8).drawCircle(0, 0, 6);
+        tinyLock.filters = [new BlurFilter(1, 40), new FXAAFilter()];
         const tinyLockTex = TextureUtil.renderToTexture(tinyLock);
 
         const maxSize = BaseTextures.BODY_SIZE - 6;
@@ -406,7 +407,7 @@ export default class BaseAssets {
             {texture: lockTexLg, scale: maxSize / texSizeLg},
             {texture: lockTexLg, scale: (maxSize / texSizeLg) * 0.75},
             {texture: lockTexSm, scale: (maxSize / texSizeSm) * 0.75 * 0.75},
-            {texture: tinyLockTex, scale: 1}
+            {texture: tinyLockTex, scale: 0.25}
         ];
     }
 


### PR DESCRIPTION
## Summary
Old
![image](https://user-images.githubusercontent.com/18635705/231902362-114b0c16-0d3a-400e-ba36-5f5b6ac886cd.png)
New
![image](https://user-images.githubusercontent.com/18635705/231902899-d48f9d03-9ef7-4b22-ba38-ca09df5e1c9c.png)

## Implementation Notes
Due to the removal of MSAA on rendered textures (2e61088c6d505015554304b24f28f685b096f16f), the smallest lock graphic comes across as square. This adds a bit of blur and FXAA to improve the antialiasing.

## Related Issues
Reported by Eli Fisker
