### PR TITLE
Improve zoom level 4 base antialiasing

### DIFF
--- a/src/eterna/pose2D/BaseAssets.ts
+++ b/src/eterna/pose2D/BaseAssets.ts
@@ -340,7 +340,7 @@ export default class BaseAssets {
         /** Size of largest glow */
         const MAX_SIZE = BaseTextures.BODY_SIZE + 6;
 
-        const getGlowTex = (renderSize: number) => {
+        const getGlowTex = (renderSize: number, blurSize = [8, 16], alpha = 1.15) => {
             const ringWrapper = new Container();
             const ringBg = new Graphics()
                 .beginFill(0)
@@ -355,7 +355,7 @@ export default class BaseAssets {
                 .lineStyle({color, width: 4})
                 .drawCircle(0, 0, renderSize / 4)
                 .endFill();
-            ring.filters = [new BlurFilter(8, 16), new AdjustmentFilter({alpha: 1.15}), new FXAAFilter()];
+            ring.filters = [new BlurFilter(...blurSize), new AdjustmentFilter({alpha}), new FXAAFilter()];
             // Center the ring in the larger texture
             ring.x = renderSize / 2;
             ring.y = renderSize / 2;
@@ -366,13 +366,14 @@ export default class BaseAssets {
 
         const texLgSize = 2 ** 7;
         const texLg = getGlowTex(texLgSize);
+        const texSmSize = 2 ** 6;
+        const texSm = getGlowTex(texSmSize, [0.75, 4], 0.6);
 
         return [
             {texture: texLg, scale: (MAX_SIZE / texLgSize) * 2},
             {texture: texLg, scale: (MAX_SIZE / texLgSize) * 2 * 0.75},
             {texture: texLg, scale: (MAX_SIZE / texLgSize) * 2 * (0.75 ** 2)},
-            // The -1 here addresses some artifacting
-            {texture: texLg, scale: ((MAX_SIZE - 1) / texLgSize) * 2 * (0.75 ** 3)}
+            {texture: texSm, scale: (MAX_SIZE / texSmSize) * 2 * (0.75 ** 3)}
         ];
     }
 

--- a/src/eterna/pose2D/BaseTextures.ts
+++ b/src/eterna/pose2D/BaseTextures.ts
@@ -56,7 +56,7 @@ export default class BaseTextures {
         /** Size of largest body texture */
         const MAX_SIZE = 40;
 
-        const getBodyTex = (texSize: number, antialias: 'none' | 'fxaa' | 'blur' | 'blur-fxaa') => {
+        const getBodyTex = (texSize: number, antialias: 'none' | 'fxaa' | 'blur' | 'blur-fxaa', blurSize = [1, 40]) => {
             Assert.assertIsDefined(Eterna.app.pixi);
             /** Render the graphic this much larger then scale down */
             const UPSCALE = texSize / MAX_SIZE;
@@ -104,7 +104,7 @@ export default class BaseTextures {
             // For some reason, global antialiasing is insufficient.
             // Maybe once smooth-graphics supports texture fills that will make this unnecessary?
             body.filters = [];
-            if (antialias === 'blur' || antialias === 'blur-fxaa') body.filters.push(new BlurFilter(1, 40));
+            if (antialias === 'blur' || antialias === 'blur-fxaa') body.filters.push(new BlurFilter(...blurSize));
             if (antialias === 'fxaa' || antialias === 'blur-fxaa') body.filters.push(new FXAAFilter());
             // Center the body in the whitespace
             body.x = (texSize / 2) - (BASE_SIZE / 2);
@@ -120,16 +120,17 @@ export default class BaseTextures {
         // For some reason, relying on global antialiasing at the smallest zoom levels creates
         // artifacting when downscaling all the way from 2^6, but 2^5 seems like the sweet spot.
         // Additionally, as we get smaller the fxaa and blur can create more artifacts than they solve
-        const texSmSize = 2 ** 4;
-        const texSmA = getBodyTex(texSmSize, 'none');
-        const texSmB = getBodyTex(texSmSize, 'none');
+        const texSmASize = 2 ** 6;
+        const texSmA = getBodyTex(texSmASize, 'blur-fxaa', [4, 60]);
+        const texSmBSize = 2 ** 4;
+        const texSmB = getBodyTex(texSmBSize, 'none');
 
         return [
             {texture: texLg, scale: MAX_SIZE / texLgSize},
             {texture: texLg, scale: (MAX_SIZE / texLgSize) * zoomScalar},
             {texture: texLg, scale: (MAX_SIZE / texLgSize) * (zoomScalar ** 2)},
-            {texture: texSmA, scale: (MAX_SIZE / texSmSize) * (zoomScalar ** 3)},
-            {texture: texSmB, scale: (MAX_SIZE / texSmSize) * (zoomScalar ** 4)}
+            {texture: texSmA, scale: (MAX_SIZE / texSmASize) * (zoomScalar ** 3)},
+            {texture: texSmB, scale: (MAX_SIZE / texSmBSize) * (zoomScalar ** 4)}
         ];
     }
 


### PR DESCRIPTION
## Summary
This improves the visual quality of bases at zoom level 4 (second-to-most zoomed out)

Old
![image](https://user-images.githubusercontent.com/18635705/231910340-57d47d8e-8860-45a5-a4f1-c59e8654fcf5.png)

New
![image](https://user-images.githubusercontent.com/18635705/231910360-5b8e53e3-b242-485b-a66b-09ddbbe95f65.png)
