### PR TITLE
Fix touchscreen interactions with potentially-scrollable regions

### DIFF
--- a/src/eterna/debug/TestMode.ts
+++ b/src/eterna/debug/TestMode.ts
@@ -1,36 +1,7 @@
 import GameMode from 'eterna/mode/GameMode';
-import PuzzleManager from 'eterna/puzzle/PuzzleManager';
-import Puzzle from 'eterna/puzzle/Puzzle';
-import SolutionManager from 'eterna/puzzle/SolutionManager';
-import Solution from 'eterna/puzzle/Solution';
-import ViewSolutionOverlay from 'eterna/mode/DesignBrowser/ViewSolutionOverlay';
 
 export default class TestMode extends GameMode {
     protected setup(): void {
         super.setup();
-
-        const puzzleID = 7656242;
-        const loadPuzzle = PuzzleManager.instance.getPuzzleByID(puzzleID);
-        const loadSolutions = SolutionManager.instance.getSolutionsForPuzzle(puzzleID);
-        Promise.all([loadPuzzle, loadSolutions])
-            .then(([puzzle, solutions]) => {
-                this.showActionBox(puzzle, solutions[0]);
-            });
-    }
-
-    private showActionBox(puzzle: Puzzle, solution: Solution): void {
-        const actionBox = new ViewSolutionOverlay({
-            solution,
-            puzzle,
-            voteDisabled: false,
-            onPrevious: () => {},
-            onNext: () => {},
-            parentMode: (() => this)()
-        });
-        this.addObject(actionBox, this.dialogLayer);
-    }
-
-    public onContextMenuEvent(e: Event): void {
-        e.preventDefault();
     }
 }

--- a/src/eterna/ui/ScrollContainer.ts
+++ b/src/eterna/ui/ScrollContainer.ts
@@ -218,12 +218,7 @@ export default class ScrollContainer extends ContainerObject {
     }
 
     /**
-     * Similar to handlePossiblyMaskedEvent. However, touch events do not have a position, only a
-     * target element, so we can't filter it like we do there. Luckily touch events aren't
-     * *actually* required for PIXI to function properly (they really should be just used as
-     * fallbacks when PointerEvents aren't available, and we expect them to be available anyways),
-     * so we can just make sure these events never get to Pixi so that it doesn't erroneously
-     * handle these events
+     * Similar to handlePossiblyMaskedEvent.
      *
      * @param e Touch event to be handled
      */


### PR DESCRIPTION
## Summary
Currently, at least in certain situations, interactions with items in potentially-scrollable regions do not properly fire interaction events.

## Implementation Notes
My guess is that something in the new event system changed behavior. Regardless, my initial comment about "touch events don't have a location" was wrong, and this handles them appropriately (or at least, I hope good enough - may want to do more testing with multitouch at some point).

## Testing
Clicking the submit button in the Chrome mobile emulator with touch emulation now works