### PR TITLE
Fix errors interacting in scrollable regions on touch devices

### DIFF
--- a/src/eterna/ui/ScrollContainer.ts
+++ b/src/eterna/ui/ScrollContainer.ts
@@ -229,13 +229,14 @@ export default class ScrollContainer extends ContainerObject {
 
         const isMaskedElement = this._htmlWrapper.contains(e.target as HTMLDivElement);
 
+        const touch = e.changedTouches[0];
         if (
             isMaskedElement
             && (
-                e.touches[0].clientX < x
-                || e.touches[0].clientX > x + width
-                || e.touches[0].clientY < y
-                || e.touches[0].clientY > y + height
+                touch.clientX < x
+                || touch.clientX > x + width
+                || touch.clientY < y
+                || touch.clientY > y + height
             )
         ) {
             // This event was fired on a location outside our clip path, and because
@@ -246,7 +247,7 @@ export default class ScrollContainer extends ContainerObject {
 
             // Find the next element "under" this element that isn't in our scroll container,
             // to re-fire the event on.
-            const candidateEls = document.elementsFromPoint(e.touches[0].clientX, e.touches[0].clientY);
+            const candidateEls = document.elementsFromPoint(touch.clientX, touch.clientY);
             const newTarget = candidateEls.find((el) => !this._htmlWrapper.contains(el));
             if (!newTarget) return;
 


### PR DESCRIPTION
## Summary
A player reported the following issue on mobile
![image](https://user-images.githubusercontent.com/18635705/232848396-08bbc877-a263-4e65-8561-c7d8627a8ede.png)

This resolves that error

## Implementation Notes
Not only is `touches` not always available on `touchend`, but we always want to use `changedTouches`, as that is both always defined and correlates to the actual pointer which is triggering the event, which is what we should be filtering on

## Testing
Clicking/dragging/releasing over buttons, inputs, and background in submit dialog, masked overlapping elements in end screen dialog. Tested with firefox touch emulation

## Related Issues
This addresses issues introduced in #697
