### PR TITLE
Dont crash when interacting with 3D on mobile

### DIFF
--- a/src/eterna/pose3D/PointerEventPropagator.ts
+++ b/src/eterna/pose3D/PointerEventPropagator.ts
@@ -50,7 +50,11 @@ export default class PointerEventPropagator extends GameObject {
 
     private handleEvent(e: FederatedPointerEvent | FederatedWheelEvent) {
         e.stopPropagation();
-        e.nativeEvent.stopImmediatePropagation();
+        // Apparently Pixi may actually provide a `Touch` as a nativeEvent, not a `TouchEvent`.
+        // See https://github.com/pixijs/pixijs/issues/9407
+        if ('stopImmediatePropagation' in e.nativeEvent) {
+            e.nativeEvent.stopImmediatePropagation();
+        }
 
         if (e instanceof FederatedWheelEvent) {
             this._domElement.dispatchEvent(new WheelEvent(e.type, e));


### PR DESCRIPTION
## Implementation Notes
See https://github.com/pixijs/pixijs/issues/9407

## Testing
Verified 3D puzzle interactions worked correctly on iOS