### PR TITLE
Fix offset target structure paste recording unpaired bases incorrectly

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1749,7 +1749,8 @@ export default class PoseEditMode extends GameMode {
             const startIdx = pasteResult.startAt - 1;
 
             for (let i = startIdx; i < pairs.length && i - startIdx < pasteResult.structure.length; i++) {
-                const targetPartner = pasteResult.structure.pairingPartner(i - startIdx) + startIdx;
+                const rawTargetPartner = pasteResult.structure.pairingPartner(i - startIdx);
+                const targetPartner = rawTargetPartner > -1 ? rawTargetPartner + startIdx : rawTargetPartner;
                 if (
                     targetPartner === -1
                     // This base is unconstrained


### PR DESCRIPTION
## Summary
Currently, when pasting a target structure with an offset, the result can wind up being incorrect. This is because unpaired bases in the pasted structure are also having their pairing partner being adjusted by the offset, even though it should be left as -1. This could surface in one of three ways:
1) A user may see the dialog warning about invalid target pairs even though it appears to be fully valid
2) The visible target structure may be incorrect
3) In either case, the resulting recorded target structure will be incorrect. Whether or not there are errors beyond bases that should be `-1` being offset depends on the initial structure.

## Testing
Validated correct behavior in 11627601 with sample sequence and structure provided by DigitalEmbrace