### PR TITLE
Support precomputed estimate structure

### DIFF
--- a/src/eterna/Feedback.ts
+++ b/src/eterna/Feedback.ts
@@ -1,3 +1,5 @@
+import SecStruct from './rnatypes/SecStruct';
+
 export interface BrentTheoData {
     type: string;
     score: number;
@@ -29,7 +31,8 @@ export default class Feedback {
 
     public setShapeData(
         dat: number[] | null, condition: string, index: number,
-        threshold: number | null, max: number | null, min: number | null, failed: string | null
+        threshold: number | null, max: number | null, min: number | null, failed: string | null,
+        estimateStructure: SecStruct | null
     ): void {
         if (dat != null) {
             if (this._shapeStarts.get(condition) === undefined) {
@@ -95,6 +98,16 @@ export default class Feedback {
             const faileds = this._faileds.get(condition);
             if (faileds !== undefined) {
                 faileds[index] = Feedback.EXPCODES[Feedback.EXPSTRINGS.indexOf(failed)];
+            }
+        }
+
+        if (estimateStructure) {
+            if (this._estimateStructures.get(condition) === undefined) {
+                this._estimateStructures.set(condition, []);
+            }
+            const estimateStructures = this._estimateStructures.get(condition);
+            if (estimateStructures !== undefined) {
+                estimateStructures[index] = estimateStructure;
             }
         }
     }
@@ -237,6 +250,10 @@ export default class Feedback {
         else return 0.0;
     }
 
+    public getEstimateStructure(index: number = 0, condition: string = 'SHAPE'): SecStruct | null {
+        return this._estimateStructures.get(condition)?.[index] ?? null;
+    }
+
     public getDegradationData(index: number = 0, condition: string): number[] {
         const degradationData = this._degradationData.get(condition);
         if (degradationData === undefined) {
@@ -305,6 +322,7 @@ export default class Feedback {
     private _shapeThresholds: Map<string, number[]> = new Map<string, number[]>();
     private _shapeMaxs: Map<string, number[]> = new Map<string, number[]>();
     private _shapeMins: Map<string, number[]> = new Map<string, number[]>();
+    private _estimateStructures: Map<string, SecStruct[]> = new Map<string, SecStruct[]>();
 
     private _degradationData: Map<string, number[][]> = new Map<string, number[][]>();
     private _degradationStarts: Map<string, number[]> = new Map<string, number[]>();

--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -620,6 +620,12 @@ export default class FeedbackViewMode extends GameMode {
         // This won't work if _feedback is null
         if (this._feedback == null) return;
 
+        const precomputedStructure = this._feedback.getEstimateStructure(index);
+        if (this._feedback.getEstimateStructure(index)) {
+            this._shapePairs[index] = precomputedStructure;
+            return;
+        }
+
         const shapeThreshold: number = this._feedback.getShapeThreshold(index);
         const shapeData: number[] = this._feedback.getShapeData(index);
         const startIndex: number = this._feedback.getShapeStartIndex(index);

--- a/src/eterna/puzzle/SolutionManager.ts
+++ b/src/eterna/puzzle/SolutionManager.ts
@@ -4,6 +4,7 @@ import Feedback, {BrentTheoData} from 'eterna/Feedback';
 import Sequence from 'eterna/rnatypes/Sequence';
 import {BundledAnnotationData} from 'eterna/AnnotationManager';
 import {DesignCategory} from 'eterna/mode/DesignBrowser/DesignBrowserMode';
+import SecStruct from 'eterna/rnatypes/SecStruct';
 import Solution from './Solution';
 
 interface SolutionSpec {
@@ -42,6 +43,7 @@ interface ShapeData {
     threshold: string;
     max: string;
     min: string;
+    estimate_structure?: string;
 }
 
 interface DegradationData {
@@ -163,7 +165,10 @@ export default class SolutionManager {
                             Number(synthesis['threshold']),
                             Number(synthesis['max']),
                             Number(synthesis['min']),
-                            null
+                            null,
+                            synthesis['estimate_structure']
+                                ? SecStruct.fromParens(synthesis['estimate_structure'])
+                                : null
                         );
                     }
                     if (synthesis['reactive'] === 'Degradation') {
@@ -215,7 +220,7 @@ export default class SolutionManager {
             }
 
             if (Feedback.EXPSTRINGS.indexOf(obj['SHAPE']) >= 0) {
-                newfb.setShapeData(null, 'SHAPE', 0, null, null, null, obj['SHAPE']);
+                newfb.setShapeData(null, 'SHAPE', 0, null, null, null, obj['SHAPE'], null);
             } else {
                 const protoshapeArray = obj['SHAPE'].split(',');
                 const shapeArray: number[] = protoshapeArray.map(
@@ -234,7 +239,7 @@ export default class SolutionManager {
                     ? Number(obj['SHAPE-min'])
                     : null;
 
-                newfb.setShapeData(shapeArray, 'SHAPE', 0, threshold, max, min, null);
+                newfb.setShapeData(shapeArray, 'SHAPE', 0, threshold, max, min, null, null);
             }
         }
 


### PR DESCRIPTION
## Summary
In the feedback mode, historically we've always computed the "estimate" structure by passing the sequence and SHAPE data to Vienna. This allows us to specify an estimate through other methods - in particular important for the pseudoknot challenge where pseudoknots are required.

## Testing
Loaded a design as-is, then reloaded it after specifying estimate_structure in its synthesis data in the backend
