### PR TITLE
Fix pseudoknot display in feedback mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eternajs",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eternajs",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@pixi-essentials/gradients": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eternajs",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "license": "SEE LICENSE IN LICENSE",
   "description": "Eterna game/RNA design interface",
   "scripts": {

--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -163,7 +163,6 @@ export default class FeedbackViewMode extends GameMode {
                 }
                 secstructs[ii] = secs;
             }
-            this._secstructs.push(SecStruct.fromParens(secstructs[ii]));
         }
 
         this._solutionView = new ViewSolutionOverlay({
@@ -203,11 +202,17 @@ export default class FeedbackViewMode extends GameMode {
             const poseField: PoseField = new PoseField(false, annotationManager);
             this.addObject(poseField, this.poseLayer);
 
-            const vienna: Folder | null = FolderManager.instance.getFolder(Vienna.NAME);
-            if (!vienna) {
-                throw new Error("Critical error: can't create a Vienna folder instance by name");
+            if (this._targetConditions && this._targetConditions[0]
+                && this._targetConditions[0]['type'] === 'pseudoknot') {
+                this._secstructs.push(SecStruct.fromParens(secstructs[ii], true));
+                poseField.pose.pseudoknotted = true;
+            } else {
+                const vienna: Folder | null = FolderManager.instance.getFolder(Vienna.NAME);
+                if (!vienna) {
+                    throw new Error("Critical error: can't create a Vienna folder instance by name");
+                }
+                this._secstructs.push(SecStruct.fromParens(secstructs[ii]));
             }
-            poseField.pose.scoreFolder = vienna;
             poseFields.push(poseField);
         }
         this.setPoseFields(poseFields);

--- a/src/eterna/puzzle/SolutionManager.ts
+++ b/src/eterna/puzzle/SolutionManager.ts
@@ -167,7 +167,7 @@ export default class SolutionManager {
                             Number(synthesis['min']),
                             null,
                             synthesis['estimate_structure']
-                                ? SecStruct.fromParens(synthesis['estimate_structure'])
+                                ? SecStruct.fromParens(synthesis['estimate_structure'], true)
                                 : null
                         );
                     }


### PR DESCRIPTION
## Implementation Notes
* Enables pknots in pose2D if the puzzle uses pknots
* Parses the target structure with pknots if the puzzle uses pknots
* Don't set the score folder (used for substructure energies, aligned with Vienna being used for structure prediction) if the puzzle uses pknots
* Always parse the estimate structure with pknots

## Testing
Validated loading solutions in PK90
