### PR TITLE
Support drawing 0-length hairpins

### DIFF
--- a/src/eterna/pose2D/RNALayout.ts
+++ b/src/eterna/pose2D/RNALayout.ts
@@ -307,6 +307,13 @@ export default class RNALayout {
 
     private addNodesRecursive(biPairs: number[], rootnode: RNATreeNode, startIndex: number, endIndex: number): void {
         if (startIndex > endIndex) {
+            // 0-length hairpins (not something that happens in nature, but eg contrafold could predict this)
+            if (startIndex - endIndex === 1) {
+                rootnode.children.push(new RNATreeNode());
+                return;
+            }
+
+            // Something has gone very wrong
             throw new Error(`Error occured while drawing RNA for indices ${startIndex} ${endIndex}`);
             // let tmp = endIndex;
             // endIndex = startIndex;


### PR DESCRIPTION
## Summary
When loading in the PK pilot data with precomputed estimate structures, some contrafold-derived structures caused a crash in RNALayout. While impossible in nature, Contrafold can predict 0-length hairpins, which we did not handle.

## Implementation Notes
I have opted to allocate a "virtual" node for the 0n hairpin like we do for other hairpins. This should mean that if an NNFE calculation generates a score for this node it will display, otherwise it will show as 0.

## Testing
Loaded design 11438186 in puzzle 11318423 (estimate mode)
