### PR TITLE
Surface reason for design browser load failure

### DIFF
--- a/src/eterna/mode/DesignBrowser/DesignBrowserMode.ts
+++ b/src/eterna/mode/DesignBrowser/DesignBrowserMode.ts
@@ -34,6 +34,7 @@ import MarkerBoxView from './MarkerBoxView';
 import GridLines from './GridLines';
 import DataCol from './DataCol';
 import CustomizeColumnOrderDialog from './CustomizeColumnOrderDialog';
+import ErrorDialogMode from '../ErrorDialogMode';
 
 export interface DBVote {
     canVote: boolean;
@@ -777,6 +778,7 @@ export default class DesignBrowserMode extends GameMode {
 
     private refreshSolutions(): Promise<void> {
         return SolutionManager.instance.getSolutionsForPuzzle(this._puzzle.nodeID)
+            .catch((e) => Flashbang.app.modeStack.pushMode(new ErrorDialogMode(e, 'Unable to load solutions')))
             .then(() => this.updateDataColumns());
     }
 

--- a/src/eterna/mode/ErrorDialogMode.ts
+++ b/src/eterna/mode/ErrorDialogMode.ts
@@ -9,9 +9,10 @@ import GameButton from 'eterna/ui/GameButton';
 export default class ErrorDialogMode extends AppMode {
     public readonly error: Error | ErrorEvent;
 
-    constructor(error: Error | ErrorEvent) {
+    constructor(error: Error | ErrorEvent, title = 'Fatal Error!') {
         super();
         this.error = error;
+        this._title = title;
     }
 
     public get isOpaque(): boolean { return false; }
@@ -34,7 +35,7 @@ export default class ErrorDialogMode extends AppMode {
             borderColor: 0xC0DCE7
         });
 
-        panel.title = 'Fatal Error!';
+        panel.title = this._title;
         this.addObject(panel, this.container);
 
         const panelLayout = new VLayoutContainer(0, HAlign.CENTER);
@@ -79,4 +80,6 @@ export default class ErrorDialogMode extends AppMode {
         Assert.assertIsDefined(this.regs);
         this.regs.add(this.resized.connect(updateView));
     }
+
+    private readonly _title: string;
 }

--- a/src/eterna/puzzle/SolutionManager.ts
+++ b/src/eterna/puzzle/SolutionManager.ts
@@ -68,6 +68,7 @@ export default class SolutionManager {
     public getSolutionsForPuzzle(puzzleID: number): Promise<Solution[]> {
         log.info(`Loading solutions for puzzle ${puzzleID}...`);
         return Eterna.client.getSolutions(puzzleID).then((json) => {
+            if (json['data']['error']) throw new Error(json['data']['error']);
             const solutionsData = json['data']['solutions'] as SolutionSpec[];
             this._solutions = solutionsData.map((solution) => SolutionManager.processData(solution));
             return this._solutions;


### PR DESCRIPTION
## Summary
A while back, we implemented permission/access rules for viewing designs. This has commonly caused confusion where a user tries to view designs and is left with a blank screen, not realizing they aren't logged in. This change surfaces such errors to the user so they are aware of what happened.

## Testing
Loaded puzzle as an unauthenticated user
