### PR TITLE
Consistently use EPars.DEFAULT_TEMPERATURE instead of magic number

### DIFF
--- a/src/eterna/constraints/constraints/BranchinessConstraint.ts
+++ b/src/eterna/constraints/constraints/BranchinessConstraint.ts
@@ -4,6 +4,7 @@ import {
 } from 'pixi.js';
 import Bitmaps from 'eterna/resources/Bitmaps';
 import {TextureUtil} from 'flashbang';
+import EPars from 'eterna/EPars';
 import Constraint, {BaseConstraintStatus, ConstraintContext} from '../Constraint';
 import ConstraintBox, {ConstraintBoxConfig} from '../ConstraintBox';
 
@@ -26,7 +27,7 @@ export default class BranchinessConstraint extends Constraint<BranchinessConstra
         const pseudoknots = (undoBlock.targetConditions !== undefined
             && undoBlock.targetConditions['type'] === 'pseudoknot');
 
-        const branchiness = undoBlock.branchiness(undoBlock.getPairs(37, pseudoknots));
+        const branchiness = undoBlock.branchiness(undoBlock.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots));
 
         return {
             satisfied: branchiness >= this.minBranchiness,

--- a/src/eterna/constraints/constraints/MaximumPairConstraint.ts
+++ b/src/eterna/constraints/constraints/MaximumPairConstraint.ts
@@ -46,7 +46,7 @@ abstract class MaximumPairConstraint extends Constraint<MaxPairConstraintStatus>
 
         const pseudoknots = (undoBlock.targetConditions !== undefined
             && undoBlock.targetConditions['type'] === 'pseudoknot');
-        const currentPairs: number = undoBlock.getParam(param, 37, pseudoknots) as number;
+        const currentPairs: number = undoBlock.getParam(param, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
         return {
             satisfied: (
                 currentPairs <= this.maxPairs

--- a/src/eterna/constraints/constraints/MinimumPairConstraint.ts
+++ b/src/eterna/constraints/constraints/MinimumPairConstraint.ts
@@ -46,7 +46,7 @@ abstract class MinimumPairConstraint extends Constraint<MinPairConstraintStatus>
 
         const pseudoknots = (undoBlock.targetConditions !== undefined
             && undoBlock.targetConditions['type'] === 'pseudoknot');
-        const currentPairs: number = undoBlock.getParam(param, 37, pseudoknots) as number;
+        const currentPairs: number = undoBlock.getParam(param, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
         return {
             satisfied: (
                 currentPairs >= this.minPairs

--- a/src/eterna/constraints/constraints/MinimumStackLengthConstraint.ts
+++ b/src/eterna/constraints/constraints/MinimumStackLengthConstraint.ts
@@ -6,6 +6,7 @@ import BitmapManager from 'eterna/resources/BitmapManager';
 import Bitmaps from 'eterna/resources/Bitmaps';
 import {TextureUtil} from 'flashbang';
 import Band from 'eterna/ui/Band';
+import EPars from 'eterna/EPars';
 import ConstraintBox, {ConstraintBoxConfig} from '../ConstraintBox';
 import Constraint, {BaseConstraintStatus, ConstraintContext} from '../Constraint';
 
@@ -28,7 +29,7 @@ export default class MinimumStackLengthConstraint extends Constraint<MinStackCon
         const pseudoknots = (undoBlock.targetConditions !== undefined
             && undoBlock.targetConditions['type'] === 'pseudoknot');
 
-        const stackLen = undoBlock.getParam(UndoBlockParam.STACK, 37, pseudoknots) as number;
+        const stackLen = undoBlock.getParam(UndoBlockParam.STACK, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
         return {
             satisfied: stackLen >= this.minLength,
             currentLength: stackLen

--- a/src/eterna/constraints/constraints/PseudoknotConstraint.ts
+++ b/src/eterna/constraints/constraints/PseudoknotConstraint.ts
@@ -1,5 +1,6 @@
 import BitmapManager from 'eterna/resources/BitmapManager';
 import Bitmaps from 'eterna/resources/Bitmaps';
+import EPars from 'eterna/EPars';
 import Constraint, {BaseConstraintStatus, ConstraintContext} from '../Constraint';
 import ConstraintBox, {ConstraintBoxConfig} from '../ConstraintBox';
 
@@ -18,7 +19,7 @@ export default class PseudoknotConstraint extends Constraint<BaseConstraintStatu
         }
 
         return {
-            satisfied: undoBlock.getPairs(37, true).onlyPseudoknots().numPairs() > 0
+            satisfied: undoBlock.getPairs(EPars.DEFAULT_TEMPERATURE, true).onlyPseudoknots().numPairs() > 0
         };
     }
 

--- a/src/eterna/constraints/constraints/RangePairedMaxConstraint.ts
+++ b/src/eterna/constraints/constraints/RangePairedMaxConstraint.ts
@@ -9,6 +9,7 @@ import Utility from 'eterna/util/Utility';
 import {HighlightType} from 'eterna/pose2D/HighlightBox';
 import Vienna from 'eterna/folding/Vienna';
 import Vienna2 from 'eterna/folding/Vienna2';
+import EPars from 'eterna/EPars';
 import ConstraintBox, {ConstraintBoxConfig} from '../ConstraintBox';
 import Constraint, {BaseConstraintStatus, ConstraintContext, HighlightInfo} from '../Constraint';
 
@@ -50,7 +51,7 @@ export default class RangePairedMaxConstraint extends Constraint<RangePairedMaxC
         // undefined. Instead of forcing more folding, try saying it's
         // zero.
         // AMW: no
-        if (undoBlock.getParam(UndoBlockParam.DOTPLOT, 37, pseudoknots) === undefined) {
+        if (undoBlock.getParam(UndoBlockParam.DOTPLOT, EPars.DEFAULT_TEMPERATURE, pseudoknots) === undefined) {
             undoBlock.updateMeltingPointAndDotPlot(pseudoknots);
         }
 
@@ -74,7 +75,7 @@ export default class RangePairedMaxConstraint extends Constraint<RangePairedMaxC
         }
 
         // For some reason the null-coalescing operator ?? is not supported here.
-        const dotplot = undoBlock.getParam(UndoBlockParam.DOTPLOT, 37, pseudoknots) as number[];
+        const dotplot = undoBlock.getParam(UndoBlockParam.DOTPLOT, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number[];
 
         // Look through the dotplot and find any pairs involving the implicated
         // residues.

--- a/src/eterna/constraints/constraints/TargetExpectedAccuracyConstraint.ts
+++ b/src/eterna/constraints/constraints/TargetExpectedAccuracyConstraint.ts
@@ -5,6 +5,7 @@ import {
     Container, Texture, Sprite
 } from 'pixi.js';
 import Bitmaps from 'eterna/resources/Bitmaps';
+import EPars from 'eterna/EPars';
 import ConstraintBox, {ConstraintBoxConfig} from '../ConstraintBox';
 import Constraint, {BaseConstraintStatus, ConstraintContext} from '../Constraint';
 
@@ -31,14 +32,20 @@ export default class TargetExpectedAccuracyConstraint extends Constraint<TargetE
         // undefined. Instead of forcing more folding, try saying it's
         // zero.
         // AMW: no
-        if (undoBlock.getParam(UndoBlockParam.TARGET_EXPECTED_ACCURACY, 37, pseudoknots) === undefined) {
+        if (
+            undoBlock.getParam(
+                UndoBlockParam.TARGET_EXPECTED_ACCURACY,
+                EPars.DEFAULT_TEMPERATURE,
+                pseudoknots
+            ) === undefined
+        ) {
             undoBlock.updateMeltingPointAndDotPlot(pseudoknots);
         }
 
         // For some reason the null-coalescing operator ?? is not supported here.
         const expectedAccuracy = undoBlock.getParam(
             UndoBlockParam.TARGET_EXPECTED_ACCURACY,
-            37,
+            EPars.DEFAULT_TEMPERATURE,
             pseudoknots
         ) as number | undefined || 0;
 

--- a/src/eterna/folding/Contrafold.ts
+++ b/src/eterna/folding/Contrafold.ts
@@ -5,6 +5,7 @@ import Assert from 'flashbang/util/Assert';
 import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
+import EPars from 'eterna/EPars';
 import * as ContrafoldLib from './engines/ContrafoldLib';
 import {DotPlotResult, FullEvalResult, FullFoldResult} from './engines/ContrafoldLib';
 /* eslint-enable import/no-duplicates, import/no-unresolved */
@@ -53,7 +54,7 @@ export default class ContraFold extends Folder {
         seq: Sequence,
         pairs: SecStruct,
         pseudoknotted: boolean = false,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         outNodes: number[] | null = null
     ): number {
         const key: CacheKey = {
@@ -138,7 +139,7 @@ export default class ContraFold extends Folder {
         secondBestPairs: SecStruct | null,
         desiredPairs: string | null = null,
         _pseudoknotted: boolean = false,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         gamma: number = 6.0
     ): SecStruct {
         const key: CacheKey = {
@@ -163,7 +164,7 @@ export default class ContraFold extends Folder {
     private foldSequenceImpl(
         seq: Sequence,
         _structStr: string | null = null,
-        _temp: number = 37,
+        _temp: number = EPars.DEFAULT_TEMPERATURE,
         gamma: number = 0.7
     ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
@@ -185,7 +186,7 @@ export default class ContraFold extends Folder {
     }
 
     /* override */
-    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = 37): DotPlot {
+    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = EPars.DEFAULT_TEMPERATURE): DotPlot {
         const key: CacheKey = {
             primitive: 'dotplot', seq: seq.baseArray, pairs: pairs.pairs, temp
         };

--- a/src/eterna/folding/Eternafold.ts
+++ b/src/eterna/folding/Eternafold.ts
@@ -5,6 +5,7 @@ import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 /* eslint-disable import/no-duplicates, import/no-unresolved */
+import EPars from 'eterna/EPars';
 import * as EternafoldLib from './engines/EternafoldLib';
 import {DotPlotResult, FullEvalResult, FullFoldResult} from './engines/EternafoldLib';
 /* eslint-enable import/no-duplicates, import/no-unresolved */
@@ -53,7 +54,7 @@ export default class EternaFold extends Folder {
         seq: Sequence,
         pairs: SecStruct,
         pseudoknotted: boolean = false,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         outNodes: number[] | null = null
     ): number {
         const key: CacheKey = {
@@ -138,7 +139,7 @@ export default class EternaFold extends Folder {
         secondBestPairs: SecStruct | null,
         desiredPairs: string | null = null,
         _pseudoknotted: boolean = false,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         gamma: number = 0.7
     ): SecStruct {
         const key: CacheKey = {
@@ -163,7 +164,7 @@ export default class EternaFold extends Folder {
     protected foldSequenceImpl(
         seq: Sequence,
         _structStr: string | null = null,
-        _temp: number = 37,
+        _temp: number = EPars.DEFAULT_TEMPERATURE,
         gamma: number = 6.0
     ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
@@ -185,7 +186,7 @@ export default class EternaFold extends Folder {
     }
 
     /* override */
-    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = 37): DotPlot {
+    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = EPars.DEFAULT_TEMPERATURE): DotPlot {
         const key: CacheKey = {
             primitive: 'dotplot', seq: seq.baseArray, pairs: pairs.pairs, temp
         };

--- a/src/eterna/folding/EternafoldThreshknot.ts
+++ b/src/eterna/folding/EternafoldThreshknot.ts
@@ -3,6 +3,7 @@ import EmscriptenUtil from 'eterna/emscripten/EmscriptenUtil';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 /* eslint-disable import/no-duplicates, import/no-unresolved */
+import EPars from 'eterna/EPars';
 import * as EternafoldLib from './engines/EternafoldLib';
 import {DotPlotResult} from './engines/EternafoldLib';
 import EternaFold from './Eternafold';
@@ -57,7 +58,7 @@ export default class EternaFoldThreshknot extends EternaFold {
         secondBestPairs: SecStruct | null,
         desiredPairs: string | null = null,
         pseudoknotted: boolean = false,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         gamma: number = 0.7
     ): SecStruct {
         const key: CacheKey = {
@@ -83,7 +84,7 @@ export default class EternaFoldThreshknot extends EternaFold {
     protected foldSequenceImpl(
         seq: Sequence,
         structStr: string | null = null,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         gamma: number = 6.0,
         pseudoknotted: boolean = false
     ): SecStruct {
@@ -96,7 +97,7 @@ export default class EternaFoldThreshknot extends EternaFold {
 
     private foldSequenceThresh(
         seq: Sequence,
-        temp: number = 37,
+        temp: number = EPars.DEFAULT_TEMPERATURE,
         theta: number = 0.15
     ): SecStruct {
         const seqStr = seq.sequenceString(false, false);

--- a/src/eterna/folding/Folder.ts
+++ b/src/eterna/folding/Folder.ts
@@ -3,6 +3,7 @@ import {Oligo} from 'eterna/rnatypes/Oligo';
 import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
+import EPars from 'eterna/EPars';
 
 export type CacheItem = SecStruct | number[] | FullEvalCache | MultiFoldResult |
 SuboptEnsembleResult | number | undefined;
@@ -40,14 +41,14 @@ export default abstract class Folder {
 
     public scoreStructures(
         _seq: Sequence, _secstruct: SecStruct, _pseudoknotted: boolean = false,
-        _temp: number = 37, _outNodes: number[] | null = null
+        _temp: number = EPars.DEFAULT_TEMPERATURE, _outNodes: number[] | null = null
     ): number {
         return 0;
     }
 
     public foldSequence(
         _seq: Sequence, _secstruct: SecStruct | null, _desiredPairs: string | null = null,
-        _pseudoknotted: boolean = false, _temp: number = 37
+        _pseudoknotted: boolean = false, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct | null {
         return null;
     }
@@ -58,7 +59,7 @@ export default abstract class Folder {
 
     public foldSequenceWithBindingSite(
         _seq: Sequence, _secstruct: SecStruct | null, _bindingSite: number[], _bonus: number,
-        _version: number = 2.0, _temp: number = 37
+        _version: number = 2.0, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct | null {
         return null;
     }
@@ -69,7 +70,7 @@ export default abstract class Folder {
 
     public cofoldSequence(
         _seq: Sequence, _secstruct: SecStruct | null, _malus: number = 0,
-        _desiredPairs: string | null = null, _temp: number = 37
+        _desiredPairs: string | null = null, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct | null {
         return null;
     }
@@ -80,7 +81,7 @@ export default abstract class Folder {
 
     public cofoldSequenceWithBindingSite(
         _seq: Sequence, _bindingSite: number[], _bonus: number, _desiredPairs: string | null = null,
-        _malus: number = 0, _temp: number = 37
+        _malus: number = 0, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct | null {
         return null;
     }
@@ -94,7 +95,10 @@ export default abstract class Folder {
     }
 
     public getSuboptEnsembleNoBindingSite(
-        _seq: Sequence, _kcalDeltaRange: number, _pseudoknotted: boolean = false, _temp: number = 37
+        _seq: Sequence,
+        _kcalDeltaRange: number,
+        _pseudoknotted: boolean = false,
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SuboptEnsembleResult {
         return {
             suboptStructures: [],
@@ -104,13 +108,17 @@ export default abstract class Folder {
     }
 
     public getDefect(
-        _seq: Sequence, _pairs: SecStruct, _temp: number = 37, _pseudoknotted: boolean = false
+        _seq: Sequence, _pairs: SecStruct, _temp: number = EPars.DEFAULT_TEMPERATURE, _pseudoknotted: boolean = false
     ): number {
         return -1;
     }
 
     public getSuboptEnsembleWithOligos(
-        _seq: Sequence, _oligos: string[], _kcalDeltaRange: number, _pseudoknotted: boolean = false, _temp: number = 37
+        _seq: Sequence,
+        _oligos: string[],
+        _kcalDeltaRange: number,
+        _pseudoknotted: boolean = false,
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SuboptEnsembleResult {
         return {
 
@@ -121,7 +129,7 @@ export default abstract class Folder {
     }
 
     public getDotPlot(
-        _seq: Sequence, _secstruct: SecStruct, _temp: number = 37, _pseudoknots: boolean = false
+        _seq: Sequence, _secstruct: SecStruct, _temp: number = EPars.DEFAULT_TEMPERATURE, _pseudoknots: boolean = false
     ): DotPlot | null {
         return null;
     }
@@ -132,14 +140,14 @@ export default abstract class Folder {
 
     public multifold(
         _seq: Sequence, _secstruct: SecStruct | null, _oligos: Oligo[],
-        _desiredPairs: string | null = null, _temp: number = 37
+        _desiredPairs: string | null = null, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): MultiFoldResult | undefined {
         return undefined;
     }
 
     public multifoldUnroll(
         _seq: Sequence, _secstruct: SecStruct | null, _oligos: Oligo[],
-        _desiredPairs: string | null = null, _temp: number = 37
+        _desiredPairs: string | null = null, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): PoseOp[] | null {
         return null;
     }

--- a/src/eterna/folding/LinearFoldBase.ts
+++ b/src/eterna/folding/LinearFoldBase.ts
@@ -5,6 +5,7 @@ import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 /* eslint-disable import/no-duplicates, import/no-unresolved */
+import EPars from 'eterna/EPars';
 import * as LinearFoldLib from './engines/LinearFoldLib';
 import {DotPlotResult, FullFoldResult} from './engines/LinearFoldLib';
 import {FullEvalResult} from './engines/ViennaLib';
@@ -22,7 +23,7 @@ export default abstract class LinearFoldBase extends Folder {
         return true;
     }
 
-    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = 37): DotPlot {
+    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = EPars.DEFAULT_TEMPERATURE): DotPlot {
         const key: CacheKey = {
             primitive: 'dotplot', seq: seq.baseArray, pairs: pairs.pairs, temp
         };
@@ -64,7 +65,7 @@ export default abstract class LinearFoldBase extends Folder {
 
     public scoreStructures(
         seq: Sequence, pairs: SecStruct, pseudoknotted: boolean = false,
-        temp: number = 37, outNodes: number[] | null = null
+        temp: number = EPars.DEFAULT_TEMPERATURE, outNodes: number[] | null = null
     ): number {
         const key: CacheKey = {
             primitive: 'score', seq: seq.baseArray, pairs: pairs.pairs, temp
@@ -149,7 +150,7 @@ export default abstract class LinearFoldBase extends Folder {
 
     public foldSequence(
         seq: Sequence, secondBestPairs: SecStruct | null, desiredPairs: string | null = null,
-        _pseudoknotted: boolean = false, temp: number = 37
+        _pseudoknotted: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key: CacheKey = {
             primitive: 'fold',
@@ -195,7 +196,7 @@ export default abstract class LinearFoldBase extends Folder {
 
     public foldSequenceWithBindingSite(
         seq: Sequence, _targetPairs: SecStruct, _bindingSite: number[], _bonus: number,
-        _version: number = 1.0, _temp: number = 37
+        _version: number = 1.0, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         log.warn('LinearFold.foldSequenceWithBindingSite: unimplemented');
         return this.foldSequence(seq, null);
@@ -207,7 +208,7 @@ export default abstract class LinearFoldBase extends Folder {
 
     public cofoldSequence(
         seq: Sequence, _secondBestPairs: SecStruct | null, _malus: number = 0,
-        _desiredPairs: string | null = null, _temp: number = 37
+        _desiredPairs: string | null = null, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         log.warn('LinearFold.cofoldSequence: unimplemented');
         return this.foldSequence(seq, null);
@@ -219,7 +220,7 @@ export default abstract class LinearFoldBase extends Folder {
 
     public cofoldSequenceWithBindingSite(
         seq: Sequence, _bindingSite: number[], _bonus: number, _desiredPairs: string | null = null,
-        _malus: number = 0, _temp: number = 37
+        _malus: number = 0, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         log.warn('LinearFold.cofoldSequenceWithBindingSite: unimplemented');
         return this.foldSequence(seq, null);

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -1,5 +1,5 @@
 import * as log from 'loglevel';
-import {RNABase} from 'eterna/EPars';
+import EPars, {RNABase} from 'eterna/EPars';
 import EmscriptenUtil from 'eterna/emscripten/EmscriptenUtil';
 import PoseOp from 'eterna/pose2D/PoseOp';
 import int from 'eterna/util/int';
@@ -50,7 +50,10 @@ export default class NuPACK extends Folder {
     }
 
     /* override */
-    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = 37, _pseudoknots: boolean = false): DotPlot {
+    public getDotPlot(
+        seq: Sequence, pairs: SecStruct,
+        temp: number = EPars.DEFAULT_TEMPERATURE, _pseudoknots: boolean = false
+    ): DotPlot {
         // AMW TODO: actually NOT pk aware yet
         const key: CacheKey = {
             primitive: 'dotplot', seq: seq.baseArray, pairs: pairs.pairs, temp
@@ -90,8 +93,10 @@ export default class NuPACK extends Folder {
     }
 
     /* override */
-    public getSuboptEnsembleWithOligos(seq: Sequence, oligoStrings: string[], kcalDeltaRange: number,
-        pseudoknotted: boolean = false, temp: number = 37): SuboptEnsembleResult {
+    public getSuboptEnsembleWithOligos(
+        seq: Sequence, oligoStrings: string[], kcalDeltaRange: number,
+        pseudoknotted: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE
+    ): SuboptEnsembleResult {
         const key = {
             primitive: 'subopt',
             seq: seq.baseArray,
@@ -151,7 +156,10 @@ export default class NuPACK extends Folder {
     }
 
     /* override */
-    public getDefect(seq: Sequence, pairs: SecStruct, temp: number = 37, pseudoknotted: boolean = false): number {
+    public getDefect(
+        seq: Sequence, pairs: SecStruct,
+        temp: number = EPars.DEFAULT_TEMPERATURE, pseudoknotted: boolean = false
+    ): number {
         const key = {
             primitive: 'defect',
             seq: seq.baseArray,
@@ -178,8 +186,10 @@ export default class NuPACK extends Folder {
     }
 
     /* override */
-    public getSuboptEnsembleNoBindingSite(seq: Sequence, kcalDeltaRange: number,
-        pseudoknotted: boolean = false, temp: number = 37): SuboptEnsembleResult {
+    public getSuboptEnsembleNoBindingSite(
+        seq: Sequence, kcalDeltaRange: number,
+        pseudoknotted: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE
+    ): SuboptEnsembleResult {
         const key = {
             primitive: 'subopt',
             seq: seq.baseArray,
@@ -240,7 +250,7 @@ export default class NuPACK extends Folder {
     /* override */
     public scoreStructures(
         seq: Sequence, pairs: SecStruct,
-        pseudoknots: boolean = false, temp: number = 37, outNodes: number[] | null = null
+        pseudoknots: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE, outNodes: number[] | null = null
     ): number {
         // See https://github.com/eternagame/EternaJS/issues/654
         if (pseudoknots) return 0;
@@ -344,7 +354,7 @@ export default class NuPACK extends Folder {
     /* override */
     public foldSequence(
         seq: Sequence, secondBestPairs: SecStruct | null, desiredPairs: string | null = null,
-        pseudoknots: boolean = false, temp: number = 37
+        pseudoknots: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key = {
             primitive: 'fold',
@@ -372,7 +382,7 @@ export default class NuPACK extends Folder {
     /* override */
     public foldSequenceWithBindingSite(
         seq: Sequence, targetPairs: SecStruct | null, bindingSite: number[], bonus: number,
-        version: number = 1.0, temp: number = 37
+        version: number = 1.0, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key = {
             primitive: 'foldAptamer',
@@ -425,7 +435,7 @@ export default class NuPACK extends Folder {
     /* override */
     public cofoldSequence(
         seq: Sequence, secondBestPairs: SecStruct, malus: number = 0,
-        desiredPairs: string | null = null, temp: number = 37
+        desiredPairs: string | null = null, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const cut: number = seq.findCut();
         if (cut < 0) {
@@ -478,7 +488,7 @@ export default class NuPACK extends Folder {
     /* override */
     public cofoldSequenceWithBindingSite(
         seq: Sequence, bindingSite: number[], bonus: number, desiredPairs: string | null = null,
-        malus: number = 0, temp: number = 37
+        malus: number = 0, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const cut: number = seq.findCut();
         if (cut < 0) {
@@ -565,7 +575,7 @@ export default class NuPACK extends Folder {
         secondBestPairs: SecStruct,
         oligos: Oligo[],
         desiredPairs: string | null = null,
-        temp: number = 37
+        temp: number = EPars.DEFAULT_TEMPERATURE
     ): MultiFoldResult {
         const key: CacheKey = {
             primitive: 'multifold',
@@ -651,7 +661,7 @@ export default class NuPACK extends Folder {
         secondBestPairs: SecStruct,
         oligos: Oligo[],
         desiredPairs: string | null = null,
-        temp: number = 37
+        temp: number = EPars.DEFAULT_TEMPERATURE
     ): PoseOp[] {
         const ops: PoseOp[] = [];
 
@@ -695,7 +705,10 @@ export default class NuPACK extends Folder {
         return ops;
     }
 
-    private foldSequenceImpl(seq: Sequence, temp: number = 37, pseudoknots: boolean = false): SecStruct {
+    private foldSequenceImpl(
+        seq: Sequence,
+        temp: number = EPars.DEFAULT_TEMPERATURE, pseudoknots: boolean = false
+    ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
 
         let result: FullFoldResult | null = null;
@@ -717,7 +730,8 @@ export default class NuPACK extends Folder {
     }
 
     private foldSequenceWithBindingSiteImpl(
-        seq: Sequence, i: number, p: number, j: number, q: number, bonus: number, _temp: number = 37
+        seq: Sequence, i: number, p: number, j: number, q: number, bonus: number,
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
 
@@ -771,7 +785,7 @@ export default class NuPACK extends Folder {
         j: number,
         q: number,
         bonus: number,
-        _temp: number = 37
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const seqStr = seq.sequenceString(true, false);
 
@@ -795,7 +809,8 @@ export default class NuPACK extends Folder {
     }
 
     private cofoldSeq2(
-        seq: Sequence, secondBestPairs: SecStruct | null, desiredPairs: string | null = null, temp: number = 37
+        seq: Sequence, secondBestPairs: SecStruct | null, desiredPairs: string | null = null,
+        temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key: CacheKey = {
             primitive: 'cofold2',

--- a/src/eterna/folding/RNAFoldBasic.ts
+++ b/src/eterna/folding/RNAFoldBasic.ts
@@ -22,7 +22,7 @@ export default class RNAFoldBasic extends Folder {
 
     public scoreStructures(
         seq: Sequence, pairs: SecStruct, _pseudoknotted: boolean = false,
-        _temp: number = 37, _outNodes: number[] | null = null
+        _temp: number = EPars.DEFAULT_TEMPERATURE, _outNodes: number[] | null = null
     ): number {
         let score = 0;
 
@@ -41,7 +41,7 @@ export default class RNAFoldBasic extends Folder {
 
     public foldSequence(
         seq: Sequence, _secondBestPairs: SecStruct | null, _desiredPairs: string | null = null,
-        _pseudoknotted: boolean = false, _temp: number = 37
+        _pseudoknotted: boolean = false, _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const n: number = seq.length;
         const pairs: SecStruct = new SecStruct(new Array(n).fill(-1));

--- a/src/eterna/folding/Vienna.ts
+++ b/src/eterna/folding/Vienna.ts
@@ -6,6 +6,7 @@ import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 /* eslint-disable import/no-duplicates, import/no-unresolved */
+import EPars from 'eterna/EPars';
 import * as ViennaLib from './engines/ViennaLib';
 import {DotPlotResult, FullEvalResult, FullFoldResult} from './engines/ViennaLib';
 /* eslint-enable import/no-duplicates, import/no-unresolved */
@@ -37,7 +38,7 @@ export default class Vienna extends Folder {
         return true;
     }
 
-    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = 37): DotPlot {
+    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = EPars.DEFAULT_TEMPERATURE): DotPlot {
         const key: CacheKey = {
             primitive: 'dotplot', seq: seq.baseArray, pairs: pairs.pairs, temp
         };
@@ -105,7 +106,7 @@ export default class Vienna extends Folder {
 
     public scoreStructures(
         seq: Sequence, pairs: SecStruct, pseudoknotted: boolean = false,
-        temp: number = 37, outNodes: number[] | null = null
+        temp: number = EPars.DEFAULT_TEMPERATURE, outNodes: number[] | null = null
     ): number {
         const key: CacheKey = {
             primitive: 'score', seq: seq.baseArray, pairs: pairs.pairs, temp
@@ -189,7 +190,7 @@ export default class Vienna extends Folder {
 
     public foldSequence(
         seq: Sequence, secondBestPairs: SecStruct | null, desiredPairs: string | null = null,
-        _pseudoknotted: boolean = false, temp: number = 37
+        _pseudoknotted: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key: CacheKey = {
             primitive: 'fold',
@@ -215,7 +216,7 @@ export default class Vienna extends Folder {
 
     public foldSequenceWithBindingSite(
         seq: Sequence, targetPairs: SecStruct | null, bindingSite: number[], bonus: number,
-        version: number = 1.0, temp: number = 37
+        version: number = 1.0, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key: CacheKey = {
             primitive: 'foldAptamer',
@@ -285,7 +286,7 @@ export default class Vienna extends Folder {
 
     public cofoldSequence(
         seq: Sequence, secondBestPairs: SecStruct | null, malus: number = 0,
-        desiredPairs: string | null = null, temp: number = 37
+        desiredPairs: string | null = null, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const cut: number = seq.findCut();
         if (cut < 0) {
@@ -336,7 +337,7 @@ export default class Vienna extends Folder {
 
     public cofoldSequenceWithBindingSite(
         seq: Sequence, bindingSite: number[], bonus: number, desiredPairs: string | null = null,
-        malus: number = 0, temp: number = 37
+        malus: number = 0, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const cut: number = seq.findCut();
         if (cut < 0) {
@@ -412,7 +413,9 @@ export default class Vienna extends Folder {
         return 0;
     }
 
-    private foldSequenceImpl(seq: Sequence, structStr: string | null = null, temp: number = 37): SecStruct {
+    private foldSequenceImpl(
+        seq: Sequence, structStr: string | null = null, temp: number = EPars.DEFAULT_TEMPERATURE
+    ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
         let result: FullFoldResult | null = null;
 
@@ -434,7 +437,8 @@ export default class Vienna extends Folder {
     }
 
     private foldSequenceWithBindingSiteImpl(
-        seq: Sequence, i: number, p: number, j: number, q: number, bonus: number, _temp: number = 37
+        seq: Sequence, i: number, p: number, j: number, q: number, bonus: number,
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
         const structStr = '';
@@ -457,7 +461,9 @@ export default class Vienna extends Folder {
         }
     }
 
-    private cofoldSequenceImpl(seq: Sequence, str: string | null = null, _temp: number = 37): SecStruct {
+    private cofoldSequenceImpl(
+        seq: Sequence, str: string | null = null, _temp: number = EPars.DEFAULT_TEMPERATURE
+    ): SecStruct {
         const seqStr = seq.sequenceString(true, false);
         const structStr: string = str || '';
         let result: FullFoldResult | null = null;
@@ -488,7 +494,7 @@ export default class Vienna extends Folder {
         j: number,
         q: number,
         bonus: number,
-        _temp: number = 37
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const seqStr = seq.sequenceString(true, false);
         const structStr: string = str || '';
@@ -513,7 +519,8 @@ export default class Vienna extends Folder {
     }
 
     private foldSequenceWithBindingSiteOld(
-        seq: Sequence, targetPairs: SecStruct, bindingSite: number[], bonus: number, _temp: number = 37
+        seq: Sequence, targetPairs: SecStruct, bindingSite: number[], bonus: number,
+        _temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         let bestPairs: SecStruct;
         const nativePairs: SecStruct = this.foldSequence(seq, null, null);

--- a/src/eterna/folding/Vienna2.ts
+++ b/src/eterna/folding/Vienna2.ts
@@ -6,6 +6,7 @@ import DotPlot from 'eterna/rnatypes/DotPlot';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import Sequence from 'eterna/rnatypes/Sequence';
 /* eslint-disable import/no-duplicates, import/no-unresolved */
+import EPars from 'eterna/EPars';
 import * as Vienna2Lib from './engines/Vienna2Lib';
 import {DotPlotResult, FullEvalResult, FullFoldResult} from './engines/Vienna2Lib';
 /* eslint-enable import/no-duplicates, import/no-unresolved */
@@ -39,7 +40,7 @@ export default class Vienna2 extends Folder {
     }
 
     /* override */
-    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = 37): DotPlot {
+    public getDotPlot(seq: Sequence, pairs: SecStruct, temp: number = EPars.DEFAULT_TEMPERATURE): DotPlot {
         const key: CacheKey = {
             primitive: 'dotplot', seq: seq.baseArray, pairs: pairs.pairs, temp
         };
@@ -111,7 +112,7 @@ export default class Vienna2 extends Folder {
     /* override */
     public scoreStructures(
         seq: Sequence, pairs: SecStruct, pseudoknotted: boolean = false,
-        temp: number = 37, outNodes: number[] | null = null
+        temp: number = EPars.DEFAULT_TEMPERATURE, outNodes: number[] | null = null
     ): number {
         const key: CacheKey = {
             primitive: 'score', seq: seq.baseArray, pairs: pairs.pairs, temp
@@ -196,7 +197,7 @@ export default class Vienna2 extends Folder {
     /* override */
     public foldSequence(
         seq: Sequence, secondBestPairs: SecStruct | null, desiredPairs: string | null = null,
-        _pseudoknotted: boolean = false, temp: number = 37
+        _pseudoknotted: boolean = false, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key: CacheKey = {
             primitive: 'fold',
@@ -223,7 +224,7 @@ export default class Vienna2 extends Folder {
     /* override */
     public foldSequenceWithBindingSite(
         seq: Sequence, targetPairs: SecStruct | null, bindingSite: number[], bonus: number,
-        version: number = 1.0, temp: number = 37
+        version: number = 1.0, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const key: CacheKey = {
             primitive: 'foldAptamer',
@@ -296,7 +297,7 @@ export default class Vienna2 extends Folder {
     /* override */
     public cofoldSequence(
         seq: Sequence, secondBestPairs: SecStruct | null, malus: number = 0,
-        desiredPairs: string | null = null, temp: number = 37
+        desiredPairs: string | null = null, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const cut: number = seq.findCut();
         if (cut < 0) {
@@ -349,7 +350,7 @@ export default class Vienna2 extends Folder {
     /* override */
     public cofoldSequenceWithBindingSite(
         seq: Sequence, bindingSite: number[], bonus: number, desiredPairs: string | null = null,
-        malus: number = 0, temp: number = 37
+        malus: number = 0, temp: number = EPars.DEFAULT_TEMPERATURE
     ): SecStruct {
         const cut: number = seq.findCut();
         if (cut < 0) {
@@ -444,7 +445,9 @@ export default class Vienna2 extends Folder {
         return 0;
     }
 
-    private foldSequenceImpl(seq: Sequence, structStr: string | null = null, temp: number = 37): SecStruct {
+    private foldSequenceImpl(
+        seq: Sequence, structStr: string | null = null, temp: number = EPars.DEFAULT_TEMPERATURE
+    ): SecStruct {
         const seqStr = seq.sequenceString(false, false);
         let result: FullFoldResult | null = null;
 

--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -33,6 +33,7 @@ import AnnotationManager from 'eterna/AnnotationManager';
 import ToolbarButton from 'eterna/ui/toolbar/ToolbarButton';
 import StateToggle from 'eterna/ui/StateToggle';
 import ModeBar from 'eterna/ui/ModeBar';
+import EPars from 'eterna/EPars';
 import ViewSolutionOverlay from './DesignBrowser/ViewSolutionOverlay';
 import GameMode from './GameMode';
 
@@ -544,9 +545,9 @@ export default class FeedbackViewMode extends GameMode {
 
         const undoBlock = this._undoBlocks[this._curTargetIndex];
         const pseudoknots = undoBlock.targetConditions?.type === 'pseudoknot';
-        const numAU: number = undoBlock.getParam(UndoBlockParam.AU, 37, pseudoknots) as number;
-        const numGU: number = undoBlock.getParam(UndoBlockParam.GU, 37, pseudoknots) as number;
-        const numGC: number = undoBlock.getParam(UndoBlockParam.GC, 37, pseudoknots) as number;
+        const numAU: number = undoBlock.getParam(UndoBlockParam.AU, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
+        const numGU: number = undoBlock.getParam(UndoBlockParam.GU, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
+        const numGC: number = undoBlock.getParam(UndoBlockParam.GC, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
         this._toolbar.palette.setPairCounts(numAU, numGU, numGC);
 
         if (this._specBox) {

--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -237,7 +237,7 @@ export default abstract class GameMode extends AppMode {
                         targetPairs,
                         "This poses's targetPairs are undefined; energy delta cannot be computed!"
                     );
-                    const nativePairs: SecStruct = ublk.getPairs(37, pseudoknots);
+                    const nativePairs: SecStruct = ublk.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots);
                     const targetSeq = EPars.constructFullSequence(
                         newField.pose.sequence,
                         ublk.targetOligo,

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1246,7 +1246,9 @@ export default class PoseEditMode extends GameMode {
             }
             const ublk = this.getCurrentUndoBlock(indx);
             const pseudoknots = ublk.targetConditions?.type === 'pseudoknot';
-            return this.getCurrentUndoBlock(indx).getParam(UndoBlockParam.FE, 37, pseudoknots) as number;
+            return this.getCurrentUndoBlock(indx).getParam(
+                UndoBlockParam.FE, EPars.DEFAULT_TEMPERATURE, pseudoknots
+            ) as number;
         });
 
         this._scriptInterface.addCallback('check_constraints', (): boolean => this.checkConstraints());
@@ -1342,8 +1344,10 @@ export default class PoseEditMode extends GameMode {
             });
 
         this._scriptInterface.addCallback('subopt_single_sequence',
-            (seq: string, kcalDelta: number,
-                pseudoknotted: boolean, temp: number = 37): SuboptEnsembleResult | null => {
+            (
+                seq: string, kcalDelta: number,
+                pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
+            ): SuboptEnsembleResult | null => {
                 if (this._folder === null) {
                     return null;
                 }
@@ -1354,8 +1358,10 @@ export default class PoseEditMode extends GameMode {
             });
 
         this._scriptInterface.addCallback('subopt_oligos',
-            (seq: string, oligoStrings: string[], kcalDelta: number,
-                pseudoknotted: boolean, temp: number = 37): SuboptEnsembleResult | null => {
+            (
+                seq: string, oligoStrings: string[], kcalDelta: number,
+                pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
+            ): SuboptEnsembleResult | null => {
                 if (this._folder === null) {
                     return null;
                 }
@@ -1373,7 +1379,9 @@ export default class PoseEditMode extends GameMode {
             });
 
         this._scriptInterface.addCallback('cofold',
-            (seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null): string | null => {
+            (
+                seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null
+            ): string | null => {
                 if (this._folder === null) {
                     return null;
                 }
@@ -1391,7 +1399,9 @@ export default class PoseEditMode extends GameMode {
             });
 
         this._scriptInterface.addCallback('get_defect',
-            (seq: string, secstruct: string, pseudoknotted: boolean, temp: number = 37): number | null => {
+            (
+                seq: string, secstruct: string, pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
+            ): number | null => {
                 if (this._folder === null) {
                     return null;
                 }
@@ -2224,11 +2234,13 @@ export default class PoseEditMode extends GameMode {
         // / Generate dot and melting plot data
         const datablock: UndoBlock = this.getCurrentUndoBlock();
         const pseudoknots = datablock.targetConditions?.type === 'pseudoknot';
-        if (datablock.getParam(UndoBlockParam.DOTPLOT_BITMAP, 37, pseudoknots) == null) {
+        if (datablock.getParam(UndoBlockParam.DOTPLOT_BITMAP, EPars.DEFAULT_TEMPERATURE, pseudoknots) == null) {
             this.updateCurrentBlockWithDotAndMeltingPlot();
         }
 
-        const initScore: number = datablock.getParam(UndoBlockParam.PROB_SCORE, 37, pseudoknots) as number;
+        const initScore: number = datablock.getParam(
+            UndoBlockParam.PROB_SCORE, EPars.DEFAULT_TEMPERATURE, pseudoknots
+        ) as number;
 
         let meltpoint = 107;
         for (let ii = 47; ii < 100; ii += 10) {
@@ -2239,7 +2251,7 @@ export default class PoseEditMode extends GameMode {
             }
         }
 
-        datablock.setParam(UndoBlockParam.MELTING_POINT, meltpoint, 37, pseudoknots);
+        datablock.setParam(UndoBlockParam.MELTING_POINT, meltpoint, EPars.DEFAULT_TEMPERATURE, pseudoknots);
 
         const dialog = new SubmitPoseDialog(this._savedInputs);
         dialog.saveInputs.connect((e) => {
@@ -2304,20 +2316,26 @@ export default class PoseEditMode extends GameMode {
         const pseudoknots = undoBlock.targetConditions?.type === 'pseudoknot';
 
         postData['title'] = details.title;
-        postData['energy'] = undoBlock.getParam(UndoBlockParam.FE, 37, pseudoknots) as number / 100.0;
+        postData['energy'] = undoBlock.getParam(
+            UndoBlockParam.FE, EPars.DEFAULT_TEMPERATURE, pseudoknots
+        ) as number / 100.0;
         postData['puznid'] = this._puzzle.nodeID;
         postData['sequence'] = seqString;
-        postData['repetition'] = undoBlock.getParam(UndoBlockParam.REPETITION, 37, pseudoknots) as number;
-        postData['gu'] = undoBlock.getParam(UndoBlockParam.GU, 37, pseudoknots) as number;
-        postData['gc'] = undoBlock.getParam(UndoBlockParam.GC, 37, pseudoknots) as number;
-        postData['ua'] = undoBlock.getParam(UndoBlockParam.AU, 37, pseudoknots) as number;
+        postData['repetition'] = undoBlock.getParam(
+            UndoBlockParam.REPETITION, EPars.DEFAULT_TEMPERATURE, pseudoknots
+        ) as number;
+        postData['gu'] = undoBlock.getParam(UndoBlockParam.GU, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
+        postData['gc'] = undoBlock.getParam(UndoBlockParam.GC, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
+        postData['ua'] = undoBlock.getParam(UndoBlockParam.AU, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
         postData['body'] = details.comment;
         if (details.annotations) {
             postData['annotations'] = JSON.stringify(details.annotations);
         }
 
         if (this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL) {
-            postData['melt'] = undoBlock.getParam(UndoBlockParam.MELTING_POINT, 37, pseudoknots) as number;
+            postData['melt'] = undoBlock.getParam(
+                UndoBlockParam.MELTING_POINT, EPars.DEFAULT_TEMPERATURE, pseudoknots
+            ) as number;
 
             const fd: FoldData[] = [];
             for (let ii = 0; ii < this._poses.length; ii++) {
@@ -2725,7 +2743,9 @@ export default class PoseEditMode extends GameMode {
             const puzzledef: PuzzleEditPoseData = {
                 sequence: pose.sequence.sequenceString(),
                 structure: (
-                    this._poseState === PoseState.TARGET ? ublk.targetPairs : ublk.getPairs(37, pseudoknots)
+                    this._poseState === PoseState.TARGET
+                        ? ublk.targetPairs
+                        : ublk.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots)
                 ).getParenthesis(null, pseudoknots),
                 startingFolder: this._folder.name,
                 annotations: this._annotationManager.createAnnotationBundle()
@@ -2951,7 +2971,9 @@ export default class PoseEditMode extends GameMode {
                         this.getCurrentUndoBlock().oligoName,
                         this.getCurrentUndoBlock().oligoLabel
                     );
-                    this._poses[0].secstruct = this.getCurrentUndoBlock().getPairs(37, pseudoknots);
+                    this._poses[0].secstruct = this.getCurrentUndoBlock().getPairs(
+                        EPars.DEFAULT_TEMPERATURE, pseudoknots
+                    );
                     this._poses[0].structConstraints = (
                         this._targetConditions?.[this._curTargetIndex]?.['structure_constraints']
                     );
@@ -2966,7 +2988,9 @@ export default class PoseEditMode extends GameMode {
                     this.getCurrentUndoBlock(ii).oligoName,
                     this.getCurrentUndoBlock(ii).oligoLabel
                 );
-                this._poses[ii].secstruct = this.getCurrentUndoBlock(ii).getPairs(37, pseudoknots);
+                this._poses[ii].secstruct = this.getCurrentUndoBlock(ii).getPairs(
+                    EPars.DEFAULT_TEMPERATURE, pseudoknots
+                );
                 this._poses[ii].structConstraints = (
                     this._targetConditions?.[ii]?.['structure_constraints']
                 );
@@ -3065,9 +3089,9 @@ export default class PoseEditMode extends GameMode {
 
         if (this._pose3D) this._pose3D.sequence.value = this.getCurrentUndoBlock().sequence;
 
-        const numAU: number = undoBlock.getParam(UndoBlockParam.AU, 37, pseudoknots) as number;
-        const numGU: number = undoBlock.getParam(UndoBlockParam.GU, 37, pseudoknots) as number;
-        const numGC: number = undoBlock.getParam(UndoBlockParam.GC, 37, pseudoknots) as number;
+        const numAU: number = undoBlock.getParam(UndoBlockParam.AU, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
+        const numGU: number = undoBlock.getParam(UndoBlockParam.GU, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
+        const numGC: number = undoBlock.getParam(UndoBlockParam.GC, EPars.DEFAULT_TEMPERATURE, pseudoknots) as number;
         this._toolbar.palette.setPairCounts(numAU, numGU, numGC);
 
         if (!this._isFrozen) {
@@ -3524,7 +3548,7 @@ export default class PoseEditMode extends GameMode {
                 secondBestPairs: null,
                 oligos,
                 desiredPairs: null,
-                temp: 37
+                temp: EPars.DEFAULT_TEMPERATURE
             };
             const mfold: MultiFoldResult = this._folder.getCache(key) as MultiFoldResult;
 
@@ -3559,7 +3583,7 @@ export default class PoseEditMode extends GameMode {
 
         const undoBlock: UndoBlock = new UndoBlock(this._puzzle.transformSequence(seq, ii), this._folder.name);
         Assert.assertIsDefined(bestPairs);
-        undoBlock.setPairs(bestPairs, 37, pseudoknots);
+        undoBlock.setPairs(bestPairs, EPars.DEFAULT_TEMPERATURE, pseudoknots);
         undoBlock.targetOligos = this._targetOligos[ii];
         undoBlock.targetOligo = this._targetOligo[ii];
         undoBlock.oligoOrder = oligoOrder;
@@ -3568,7 +3592,7 @@ export default class PoseEditMode extends GameMode {
         undoBlock.targetOligoOrder = this._targetOligosOrder[ii];
         undoBlock.puzzleLocks = this._poses[ii].puzzleLocks;
         undoBlock.targetConditions = this._targetConditions[ii];
-        undoBlock.setBasics(37, pseudoknots);
+        undoBlock.setBasics(EPars.DEFAULT_TEMPERATURE, pseudoknots);
         undoBlock.librarySelections = this._poses[ii].librarySelections;
         this._seqStacks[this._stackLevel][ii] = undoBlock;
     }
@@ -3593,11 +3617,15 @@ export default class PoseEditMode extends GameMode {
 
         // / JEEFIX
 
-        let lastBestPairs: SecStruct = this._seqStacks[this._stackLevel][targetIndex].getPairs(37, pseudoknots);
+        let lastBestPairs: SecStruct = this._seqStacks[this._stackLevel][targetIndex].getPairs(
+            EPars.DEFAULT_TEMPERATURE, pseudoknots
+        );
         const bestPairs: SecStruct = lastBestPairs;
 
         if (this._stackLevel > 0) {
-            lastBestPairs = this._seqStacks[this._stackLevel - 1][targetIndex].getPairs(37, pseudoknots);
+            lastBestPairs = this._seqStacks[this._stackLevel - 1][targetIndex].getPairs(
+                EPars.DEFAULT_TEMPERATURE, pseudoknots
+            );
         }
 
         const isShapeConstrained = this._puzzle.constraints && this._puzzle.constraints.some(

--- a/src/eterna/puzzle/Puzzle.ts
+++ b/src/eterna/puzzle/Puzzle.ts
@@ -328,7 +328,7 @@ export default class Puzzle {
                     concentration = 1.0;
                 }
                 this._targetConditions[ii]['malus'] = (
-                    -Constants.BOLTZMANN * (Constants.KELVIN_0C + 37) * Math.log(concentration)
+                    -Constants.BOLTZMANN * (Constants.KELVIN_0C + EPars.DEFAULT_TEMPERATURE) * Math.log(concentration)
                 );
 
                 const label = this._targetConditions[ii]['oligo_label'];
@@ -356,7 +356,9 @@ export default class Puzzle {
                     } else {
                         concentration = 1.0;
                     }
-                    oligos[jj]['malus'] = -Constants.BOLTZMANN * (Constants.KELVIN_0C + 37) * Math.log(concentration);
+                    oligos[jj]['malus'] = -Constants.BOLTZMANN * (
+                        Constants.KELVIN_0C + EPars.DEFAULT_TEMPERATURE
+                    ) * Math.log(concentration);
                     const label = oligos[jj]['label'];
                     if (label) {
                         // To support parsing logic in AnnotationDialog

--- a/src/eterna/ui/SpecBoxDialog.ts
+++ b/src/eterna/ui/SpecBoxDialog.ts
@@ -119,7 +119,7 @@ export default class SpecBoxDialog extends WindowDialog<void> {
     }
 
     private build() {
-        const TEMPERATURE = 37;
+        const TEMPERATURE = EPars.DEFAULT_TEMPERATURE;
 
         const statString = new StyledTextBuilder({
             fontFamily: Fonts.STDFONT,


### PR DESCRIPTION
## Summary
We have a static variable for our default folding temperature, but in many situations we used the magic number 37 instead of that variable. This ensures consistent usage of the static variable

## Testing
Basic smoke checks on 20111 (simple hairpin) and 11627601 (PK100)
