### PR TITLE
Correct eternascript structure, RangePairedMaxConstraint, mfe dot plot with pseudoknots

### DIFF
--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -633,7 +633,8 @@ export default class UndoBlock {
         const currDotPlot = this.getParam(UndoBlockParam.DOTPLOT, EPars.DEFAULT_TEMPERATURE, pseudoknots);
         if (currDotPlot === undefined) {
             const dotArray: DotPlot | null = folder.getDotPlot(
-                this.sequence, this.getPairs(EPars.DEFAULT_TEMPERATURE), EPars.DEFAULT_TEMPERATURE, pseudoknots
+                this.sequence, this.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots),
+                EPars.DEFAULT_TEMPERATURE, pseudoknots
             );
             this.setParam(UndoBlockParam.DOTPLOT, dotArray?.data ?? null, EPars.DEFAULT_TEMPERATURE, pseudoknots);
             // mean+sum prob unpaired

--- a/src/eterna/constraints/constraints/RangePairedMaxConstraint.ts
+++ b/src/eterna/constraints/constraints/RangePairedMaxConstraint.ts
@@ -87,7 +87,7 @@ export default class RangePairedMaxConstraint extends Constraint<RangePairedMaxC
         const square: boolean = (undoBlock.folderName === Vienna.NAME
             || undoBlock.folderName === Vienna2.NAME);
 
-        const finalOffset = (undoBlock.getPairs()?.numPairs() ?? 0) * 3;
+        const finalOffset = (undoBlock.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots)?.numPairs() ?? 0) * 3;
 
         for (let ii = 0; ii < dotplot.length - finalOffset; ii += 3) {
             // if either index is a number-of-interest, add probability in.

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1226,7 +1226,9 @@ export default class PoseEditMode extends GameMode {
 
         this._scriptInterface.addCallback('get_native_structure', (indx: number): string | null => {
             if (indx < 0 || indx >= this._poses.length) return null;
-            const nativepairs = this.getCurrentUndoBlock(indx).getPairs();
+            const pseudoknots = this._targetConditions && this._targetConditions[0]
+                && this._targetConditions[0]['type'] === 'pseudoknot';
+            const nativepairs = this.getCurrentUndoBlock(indx).getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots);
             return nativepairs.getParenthesis();
         });
 
@@ -1235,7 +1237,11 @@ export default class PoseEditMode extends GameMode {
                 return null;
             }
 
-            const nativePairs: SecStruct = this.getCurrentUndoBlock(indx).getPairs();
+            const pseudoknots = this._targetConditions && this._targetConditions[0]
+                && this._targetConditions[0]['type'] === 'pseudoknot';
+            const nativePairs: SecStruct = this.getCurrentUndoBlock(indx).getPairs(
+                EPars.DEFAULT_TEMPERATURE, pseudoknots
+            );
             const seq: Sequence = this.getPose(indx).fullSequence;
             return nativePairs.getParenthesis(seq);
         });
@@ -1282,16 +1288,11 @@ export default class PoseEditMode extends GameMode {
                     return null;
                 }
                 const seqArr: Sequence = Sequence.fromSequenceString(seq);
-                if (this._targetConditions && this._targetConditions[0]
-                    && this._targetConditions[0]['type'] === 'pseudoknot') {
-                    const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint, true);
-                    Assert.assertIsDefined(folded);
-                    return folded.getParenthesis(null, true);
-                } else {
-                    const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint);
-                    Assert.assertIsDefined(folded);
-                    return folded.getParenthesis();
-                }
+                const pseudoknots = this._targetConditions && this._targetConditions[0]
+                    && this._targetConditions[0]['type'] === 'pseudoknot';
+                const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint, pseudoknots);
+                Assert.assertIsDefined(folded);
+                return folded.getParenthesis(null, pseudoknots);
             });
 
         this._scriptInterface.addCallback('fold_with_binding_site',

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -1036,14 +1036,11 @@ export default class PuzzleEditMode extends GameMode {
     private updateScore(): void {
         this.saveData();
 
-        const pseudoknots = this._structureInputs.some(
-            (input) => SecStruct.fromParens(input.structureString, true).onlyPseudoknots().nonempty()
-        );
-
         for (let ii = 0; ii < this._poses.length; ii++) {
             const undoblock: UndoBlock = this.getCurrentUndoBlock(ii);
             const targetPairs = this.getCurrentTargetPairs(ii);
-            const bestPairs = undoblock.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots);
+            // TODO: Should we set/get data on the undoblock with the pseudoknot parameter?
+            const bestPairs = undoblock.getPairs();
             const {sequence} = this._poses[ii];
             if (sequence.length !== targetPairs.length) {
                 throw new Error("sequence and design pairs lengths don't match");
@@ -1243,6 +1240,7 @@ export default class PuzzleEditMode extends GameMode {
             }
             Assert.assertIsDefined(bestPairs);
             const undoBlock = new UndoBlock(seq, this._folder.name);
+            // TODO: Should we set/get data on the undoblock with the pseudoknot parameter?
             undoBlock.setPairs(bestPairs);
             undoBlock.setBasics();
             undoBlock.targetPairs = targetPairs;

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -1036,10 +1036,14 @@ export default class PuzzleEditMode extends GameMode {
     private updateScore(): void {
         this.saveData();
 
+        const pseudoknots = this._structureInputs.some(
+            (input) => SecStruct.fromParens(input.structureString, true).onlyPseudoknots().nonempty()
+        );
+
         for (let ii = 0; ii < this._poses.length; ii++) {
             const undoblock: UndoBlock = this.getCurrentUndoBlock(ii);
             const targetPairs = this.getCurrentTargetPairs(ii);
-            const bestPairs = undoblock.getPairs(EPars.DEFAULT_TEMPERATURE);
+            const bestPairs = undoblock.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots);
             const {sequence} = this._poses[ii];
             if (sequence.length !== targetPairs.length) {
                 throw new Error("sequence and design pairs lengths don't match");


### PR DESCRIPTION
This fixes a few remaining issues where the `pseudoknotted` parameter wasn't being set in UndoBlock parameter retrievals where it should have been
