### PR TITLE
Fix rnapuzzler clash-free layout in feedback mode

### DIFF
--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -265,6 +265,7 @@ export default class FeedbackViewMode extends GameMode {
             datablock.setPairs(this._secstructs[ii]);
             datablock.setBasics();
             this._undoBlocks.push(datablock);
+            this._poses[ii].targetPairs = this._secstructs[ii];
         }
         for (const poseField of this._poseFields) {
             poseField.updateDeltaEnergyGui();


### PR DESCRIPTION
## Summary
Previously when viewing structures in feedback mode with the rnapuzzler clash-free layout enabled, the tha RNA would be positioned far-offscreen with a high distance between bases. PoseEdit and PuzzleEdit would display the same structure correctly.

## Implementation Notes
The issue was in feedback mode, we weren't passing the target structure to the pose, which we need to reference in rnalyout in order to apply correct scaling when laying out with rnapuzzler

## Testing
Verified layout correctness with https://eternagame.org/game/browse/11318423/?filter1=Id&filter1_arg1=11459092&filter1_arg2=11459092
