### PR TITLE
Make hotkeys more consistenly available across modes

### DIFF
--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -15,7 +15,7 @@ import PoseField from 'eterna/pose2D/PoseField';
 import FolderManager from 'eterna/folding/FolderManager';
 import Vienna from 'eterna/folding/Vienna';
 import {
-    VAlign, HAlign, DisplayUtil, KeyboardEventType, KeyCode, Assert, Flashbang
+    VAlign, HAlign, DisplayUtil, KeyCode, Assert, Flashbang
 } from 'flashbang';
 import EternaSettingsDialog, {EternaViewOptionsMode} from 'eterna/ui/EternaSettingsDialog';
 import SpecBoxDialog from 'eterna/ui/SpecBoxDialog';
@@ -357,39 +357,6 @@ export default class FeedbackViewMode extends GameMode {
 
     private showSettingsDialog(): void {
         this.showDialog(new EternaSettingsDialog(EternaViewOptionsMode.LAB), 'SettingsDialog');
-    }
-
-    public onKeyboardEvent(e: KeyboardEvent): void {
-        let handled: boolean = this.keyboardInput.handleKeyboardEvent(e);
-
-        if (!handled && e.type === KeyboardEventType.KEY_DOWN) {
-            const key = e.code;
-            const ctrl = e.ctrlKey;
-
-            if (!ctrl && key === KeyCode.KeyN) {
-                Eterna.settings.showNumbers.value = !Eterna.settings.showNumbers.value;
-                handled = true;
-            } else if (!ctrl && key === KeyCode.KeyG) {
-                Eterna.settings.displayFreeEnergies.value = !Eterna.settings.displayFreeEnergies.value;
-                handled = true;
-            } else if (key === KeyCode.BracketLeft) {
-                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor - 0.25) * 1000) / 1000);
-                for (const pf of this._poseFields) {
-                    pf.explosionFactor = factor;
-                }
-                handled = true;
-            } else if (key === KeyCode.BracketRight) {
-                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor + 0.25) * 1000) / 1000);
-                for (const pf of this._poseFields) {
-                    pf.explosionFactor = factor;
-                }
-                handled = true;
-            }
-        }
-
-        if (handled) {
-            e.stopPropagation();
-        }
     }
 
     /* override */

--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -4,7 +4,8 @@ import Eterna from 'eterna/Eterna';
 import UndoBlock, {TargetConditions} from 'eterna/UndoBlock';
 import SecStruct from 'eterna/rnatypes/SecStruct';
 import {
-    AppMode, SceneObject, Flashbang, GameObjectRef, Assert, AlphaTask, RepeatingTask, SerialTask
+    AppMode, SceneObject, Flashbang, GameObjectRef, Assert, AlphaTask, RepeatingTask, SerialTask,
+    KeyboardEventType, KeyCode
 } from 'flashbang';
 import AchievementManager from 'eterna/achievements/AchievementManager';
 import Tooltips from 'eterna/ui/Tooltips';
@@ -640,6 +641,56 @@ export default abstract class GameMode extends AppMode {
         factorDialog.factor.connect((factor) => {
             this._poseFields.forEach((pf) => { pf.explosionFactor = factor; });
         });
+    }
+
+    public onKeyboardEvent(e: KeyboardEvent): boolean {
+        let handled: boolean = super.onKeyboardEvent(e);
+
+        // We check this._poses.length > 0 because DesignBrowserMode also inherits from this mode
+        // (sigh) and all of these keybinds are tied to pose-related operations (which the
+        // design browser doesn't have)
+        if (!handled && e.type === KeyboardEventType.KEY_DOWN && this._poses.length > 0) {
+            const key = e.code;
+            const ctrl = e.ctrlKey;
+
+            if (!ctrl && key === KeyCode.KeyN) {
+                Eterna.settings.showNumbers.value = !Eterna.settings.showNumbers.value;
+                handled = true;
+            } else if (!ctrl && key === KeyCode.KeyR) {
+                Eterna.settings.showRope.value = !Eterna.settings.showRope.value;
+                handled = true;
+            } else if (!ctrl && key === KeyCode.KeyG) {
+                Eterna.settings.displayFreeEnergies.value = !Eterna.settings.displayFreeEnergies.value;
+                handled = true;
+            } else if (!ctrl && key === KeyCode.Comma) {
+                Eterna.settings.simpleGraphics.value = !Eterna.settings.simpleGraphics.value;
+                handled = true;
+            } else if (!ctrl && key === KeyCode.KeyL) {
+                Eterna.settings.usePuzzlerLayout.value = !Eterna.settings.usePuzzlerLayout.value;
+                handled = true;
+            } else if (ctrl && key === KeyCode.KeyS) {
+                this.downloadSVG();
+                handled = true;
+            } else if (key === KeyCode.BracketLeft) {
+                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor - 0.25) * 1000) / 1000);
+                for (const pf of this._poseFields) {
+                    pf.explosionFactor = factor;
+                }
+                handled = true;
+            } else if (key === KeyCode.BracketRight) {
+                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor + 0.25) * 1000) / 1000);
+                for (const pf of this._poseFields) {
+                    pf.explosionFactor = factor;
+                }
+                handled = true;
+            }
+        }
+
+        if (handled) {
+            e.stopPropagation();
+        }
+
+        return handled;
     }
 
     protected _achievements: AchievementManager;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1532,45 +1532,15 @@ export default class PoseEditMode extends GameMode {
         });
     }
 
-    public onKeyboardEvent(e: KeyboardEvent): void {
-        let handled: boolean = this.keyboardInput.handleKeyboardEvent(e);
+    public onKeyboardEvent(e: KeyboardEvent): boolean {
+        let handled: boolean = super.onKeyboardEvent(e);
 
         if (!handled && e.type === KeyboardEventType.KEY_DOWN) {
             const key = e.code;
             const ctrl = e.ctrlKey;
 
-            if (!ctrl && key === KeyCode.KeyN) {
-                Eterna.settings.showNumbers.value = !Eterna.settings.showNumbers.value;
-                handled = true;
-            } else if (!ctrl && key === KeyCode.KeyR) {
-                Eterna.settings.showRope.value = !Eterna.settings.showRope.value;
-                handled = true;
-            } else if (!ctrl && key === KeyCode.KeyG) {
-                Eterna.settings.displayFreeEnergies.value = !Eterna.settings.displayFreeEnergies.value;
-                handled = true;
-            } else if (!ctrl && key === KeyCode.Comma) {
-                Eterna.settings.simpleGraphics.value = !Eterna.settings.simpleGraphics.value;
-                handled = true;
-            } else if (!ctrl && key === KeyCode.KeyL) {
-                Eterna.settings.usePuzzlerLayout.value = !Eterna.settings.usePuzzlerLayout.value;
-                handled = true;
-            } else if (ctrl && key === KeyCode.KeyZ) {
+            if (ctrl && key === KeyCode.KeyZ) {
                 this.moveUndoStackToLastStable();
-                handled = true;
-            } else if (ctrl && key === KeyCode.KeyS) {
-                this.downloadSVG();
-                handled = true;
-            } else if (key === KeyCode.BracketLeft) {
-                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor - 0.25) * 1000) / 1000);
-                for (const pf of this._poseFields) {
-                    pf.explosionFactor = factor;
-                }
-                handled = true;
-            } else if (key === KeyCode.BracketRight) {
-                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor + 0.25) * 1000) / 1000);
-                for (const pf of this._poseFields) {
-                    pf.explosionFactor = factor;
-                }
                 handled = true;
             }
         }
@@ -1578,6 +1548,8 @@ export default class PoseEditMode extends GameMode {
         if (handled) {
             e.stopPropagation();
         }
+
+        return handled;
     }
 
     private reloadCurrentSolution(): void {

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -14,7 +14,7 @@ import {PaletteTargetType, GetPaletteTargetBaseType} from 'eterna/ui/toolbar/Nuc
 import Folder from 'eterna/folding/Folder';
 import PoseThumbnail, {PoseThumbnailType} from 'eterna/ui/PoseThumbnail';
 import {
-    Base64, DisplayUtil, HAlign, VAlign, KeyCode, Assert, KeyboardEventType, Flashbang, VLayoutContainer
+    Base64, DisplayUtil, HAlign, VAlign, KeyCode, Assert, Flashbang, VLayoutContainer
 } from 'flashbang';
 import {DialogCanceledError} from 'eterna/ui/Dialog';
 import Vienna2 from 'eterna/folding/Vienna2';
@@ -477,36 +477,6 @@ export default class PuzzleEditMode extends GameMode {
                 this.removeObject(uploadButton);
             }));
         }));
-    }
-
-    public onKeyboardEvent(e: KeyboardEvent): void {
-        let handled: boolean = this.keyboardInput.handleKeyboardEvent(e);
-
-        if (!handled && e.type === KeyboardEventType.KEY_DOWN) {
-            const key = e.code;
-            const ctrl = e.ctrlKey;
-
-            if (ctrl && key === KeyCode.KeyS) {
-                this.downloadSVG();
-                handled = true;
-            } else if (key === KeyCode.BracketLeft) {
-                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor - 0.25) * 1000) / 1000);
-                for (const pf of this._poseFields) {
-                    pf.explosionFactor = factor;
-                }
-                handled = true;
-            } else if (key === KeyCode.BracketRight) {
-                const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor + 0.25) * 1000) / 1000);
-                for (const pf of this._poseFields) {
-                    pf.explosionFactor = factor;
-                }
-                handled = true;
-            }
-        }
-
-        if (handled) {
-            e.stopPropagation();
-        }
     }
 
     private saveData(): void {

--- a/src/flashbang/core/AppMode.ts
+++ b/src/flashbang/core/AppMode.ts
@@ -186,8 +186,8 @@ export default class AppMode implements PointerTarget {
      * Called when the application receives a keyDown or keyUp event while this mode is active.
      * By default, we just pass this off to the KeyboardInput handler.
      */
-    public onKeyboardEvent(e: KeyboardEvent): void {
-        this.keyboardInput.handleKeyboardEvent(e);
+    public onKeyboardEvent(e: KeyboardEvent): boolean {
+        return this.keyboardInput.handleKeyboardEvent(e);
     }
 
     /** Called when a ContextMenu event is fired while this mode is active */


### PR DESCRIPTION
## Summary
Previously, there were a number of hotkeys available in the puzzle solver that shouldve been available in the puzzlemaker and feedback mode but were not.

## Implementation Notes
This moves handling most hotkeys to the base GameMode class. Note that the design browser also extends from game mode, and in that case the hotkeys don't make sense. For that reason, we only "register" the hotkeys related to the RNA when there are poses available

## Testing
Tried a combination of hotkeys in each mode

## Related Issues
https://forum.eternagame.org/t/puzzlemaker/3086
