### PR TITLE
Support multiple SHAPE conditions in feedback mode

### DIFF
--- a/src/eterna/Feedback.ts
+++ b/src/eterna/Feedback.ts
@@ -313,8 +313,12 @@ export default class Feedback {
     }
 
     public get conditions(): string[] {
-        const conds = ['SHAPE'];
-        return Array.prototype.concat(conds, Array.from(this._degradationData.keys()));
+        return [
+            ...Array.from(this._shapeData.keys()).map(
+                (condition) => (condition === 'SHAPE' ? 'SHAPE' : `SHAPE: ${condition}`)
+            ),
+            ...Array.from(this._degradationData.keys()).map((condition) => `Degradation: ${condition}`)
+        ];
     }
 
     private _shapeData: Map<string, number[][]> = new Map<string, number[][]>();

--- a/src/eterna/puzzle/SolutionManager.ts
+++ b/src/eterna/puzzle/SolutionManager.ts
@@ -161,7 +161,7 @@ export default class SolutionManager {
 
                         newfb.setShapeData(
                             peaks,
-                            'SHAPE', // condition
+                            synthesis['condition'] || 'SHAPE',
                             Number(synthesis['target_index']),
                             Number(synthesis['threshold']),
                             Number(synthesis['max']),


### PR DESCRIPTION
## Summary
Feedback mode now properly parses multiple SHAPE conditions in solution experimental data and uses the last-selected SHAPE condition as the basis of the estimate mode structure. Additionally, condition names in the dropdown are prefixed by the experimental method (SHAPE or Degradation)

## Implementation Notes
Still left unhandled is estimate mode when there are no available SHAPE conditions. In that case, we should remove the estimate mode button (and switch back to target mode if we're not already), but that implementation is not completely trivial, that hasn't happened yet, and everything still works if you don't switch to estimate mode

## Testing
Ensured experimental data and estimate structure displayed and updated properly given:
* Single shape condition
* Multiple shape conditions
* Multiple shape conditions + degredation conditions
