### PR TITLE
Support highlighting misfolding regions in puzzlemaker

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -47,7 +47,6 @@ import EternaURL from 'eterna/net/EternaURL';
 import PuzzleManager, {PuzzleJSON} from 'eterna/puzzle/PuzzleManager';
 import FoldUtil from 'eterna/folding/FoldUtil';
 import ShapeConstraint, {AntiShapeConstraint} from 'eterna/constraints/constraints/ShapeConstraint';
-import {HighlightType} from 'eterna/pose2D/HighlightBox';
 import Utility from 'eterna/util/Utility';
 import HintsPanel from 'eterna/ui/HintsPanel';
 import HelpBar from 'eterna/ui/HelpBar';
@@ -544,45 +543,6 @@ export default class PoseEditMode extends GameMode {
                 setTarget(ii);
             } else {
                 this._opQueue.push(new PoseOp(ii + 1, () => setTarget(ii)));
-            }
-        }
-    }
-
-    private highlightSequences(highlightInfos: HighlightInfo[] | null) {
-        for (const [poseIdx, pose] of this._poses.entries()) {
-            pose.clearRestrictedHighlight();
-            pose.clearUnstableHighlight();
-            pose.clearUserDefinedHighlight();
-            const poseState = this._isPipMode || poseIdx !== 0 ? poseIdx : this._curTargetIndex;
-            if (!highlightInfos) continue;
-            for (const highlightInfo of highlightInfos) {
-                if (highlightInfo.stateIndex !== undefined && poseState !== highlightInfo.stateIndex) {
-                    continue;
-                }
-
-                const currBlock = this.getCurrentUndoBlock(poseState);
-                const naturalMap = currBlock.reorderedOligosIndexMap(currBlock.oligoOrder);
-                const targetMap = currBlock.reorderedOligosIndexMap(currBlock.targetOligoOrder);
-                let ranges = highlightInfo.ranges;
-                if (this._poseState === PoseState.NATIVE && naturalMap !== undefined) {
-                    ranges = highlightInfo.ranges.map((index: number) => naturalMap.indexOf(index));
-                } else if (this._poseState === PoseState.TARGET && targetMap !== undefined) {
-                    ranges = highlightInfo.ranges.map((index: number) => targetMap.indexOf(index));
-                }
-
-                switch (highlightInfo.color) {
-                    case HighlightType.RESTRICTED:
-                        pose.highlightRestrictedSequence(ranges);
-                        break;
-                    case HighlightType.UNSTABLE:
-                        pose.highlightUnstableSequence(ranges);
-                        break;
-                    case HighlightType.USER_DEFINED:
-                        pose.highlightUserDefinedSequence(ranges);
-                        break;
-                    default:
-                        log.error(`Invalid highlight type: ${highlightInfo.color}`);
-                }
             }
         }
     }
@@ -3943,7 +3903,6 @@ export default class PoseEditMode extends GameMode {
     private _paused: boolean;
     private _startSolvingTime: number;
     protected _curTargetIndex: number = 0;
-    private _poseState: PoseState = PoseState.NATIVE;
     private _shouldMarkMutations: boolean = false;
 
     private _seqStacks: UndoBlock[][];

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -53,6 +53,8 @@ import ModeBar from 'eterna/ui/ModeBar';
 import {FederatedPointerEvent} from '@pixi/events';
 import GameWindow from 'eterna/ui/GameWindow';
 import FolderManager from 'eterna/folding/FolderManager';
+import {PoseState} from 'eterna/puzzle/Puzzle';
+import {HighlightInfo} from 'eterna/constraints/Constraint';
 import GameMode from '../GameMode';
 import SubmitPuzzleDialog, {SubmitPuzzleDetails} from './SubmitPuzzleDialog';
 import StructureInput from './StructureInput';
@@ -281,6 +283,9 @@ export default class PuzzleEditMode extends GameMode {
         ), this._numTargets);
         this.addObject(this._constraintBar, this.container);
         this._constraintBar.layout();
+        this._constraintBar.sequenceHighlights.connect(
+            (highlightInfos: HighlightInfo[] | null) => this.highlightSequences(highlightInfos)
+        );
 
         this._toolbar = new Toolbar(toolbarType, {
             annotationManager: this._annotationManager
@@ -918,6 +923,8 @@ export default class PuzzleEditMode extends GameMode {
     }
 
     private setToNativeMode(): void {
+        this._poseState = PoseState.NATIVE;
+
         this._targetButton.toggled.value = false;
         this._naturalButton.toggled.value = true;
 
@@ -929,6 +936,8 @@ export default class PuzzleEditMode extends GameMode {
     }
 
     private setToTargetMode(): void {
+        this._poseState = PoseState.TARGET;
+
         this._targetButton.toggled.value = true;
         this._naturalButton.toggled.value = false;
 


### PR DESCRIPTION
## Summary
Clicking the structure constraint thumbnail in puzzlemaker highlights incorrectly-folding regions of the puzzle, just like in the puzzle solver

## Implementation Notes
I've opted to move the highlight handling into the base class. This required moving `_poseState` into the base class as well. More general improvements to what the base class handles needs larger improvements, but this change seemed reasonably nondisruptive

## Testing
Verified by hand click-to-highlight still works in puzzle solver as well as verifying in editor

## Related Issues
Resolves #461
