### PR TITLE
Support folding engine switcher as a valid target for tutorial script UI commands

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -3916,6 +3916,10 @@ export default class PoseEditMode extends GameMode {
         return this._stateToggle;
     }
 
+    public get folderSwitcher(): FolderSwitcher {
+        return this._folderSwitcher;
+    }
+
     private readonly _puzzle: Puzzle;
     private readonly _params: PoseEditParams;
     private readonly _scriptInterface = new ExternalInterfaceCtx();

--- a/src/eterna/rscript/ROPHighlight.ts
+++ b/src/eterna/rscript/ROPHighlight.ts
@@ -283,12 +283,13 @@ export default class ROPHighlight extends RScriptOp {
                 break;
             case RScriptUIElementID.TOGGLENATURAL:
             case RScriptUIElementID.TOGGLETARGET:
+            case RScriptUIElementID.FOLDER:
                 break;
             case RScriptUIElementID.ACTION_MENU:
                 log.warn('ACTION_MENU rscript ui element no longer exists');
                 break;
             default:
-                log.warn(`UI element does not have size: ${key}`);
+                log.warn(`UI element does not have handled size: ${key}`);
         }
         return size;
     }
@@ -331,6 +332,7 @@ export default class ROPHighlight extends RScriptOp {
             case RScriptUIElementID.REDO:
             case RScriptUIElementID.PIP:
             case RScriptUIElementID.SWITCH:
+            case RScriptUIElementID.FOLDER:
                 return this._env.getUIElement(key);
             case RScriptUIElementID.ACTION_MENU:
                 log.warn('ACTION_MENU rscript ui element no longer exists');
@@ -385,6 +387,7 @@ export default class ROPHighlight extends RScriptOp {
             case RScriptUIElementID.UNDO:
             case RScriptUIElementID.REDO:
             case RScriptUIElementID.PIP:
+            case RScriptUIElementID.FOLDER:
                 break;
             case RScriptUIElementID.OBJECTIVES:
                 offset = new Point(-5, 0);

--- a/src/eterna/rscript/RScriptEnv.ts
+++ b/src/eterna/rscript/RScriptEnv.ts
@@ -10,7 +10,6 @@ import PoseEditMode from 'eterna/mode/PoseEdit/PoseEditMode';
 import Puzzle from 'eterna/puzzle/Puzzle';
 import Pose2D, {RNAHighlightState} from 'eterna/pose2D/Pose2D';
 import {PaletteTargetType} from 'eterna/ui/toolbar/NucleotidePalette';
-import StateToggle from 'eterna/ui/StateToggle';
 import PoseField from 'eterna/pose2D/PoseField';
 import {RScriptUIElement, RScriptUIElementID} from './RScriptUIElement';
 
@@ -215,10 +214,6 @@ export default class RScriptEnv extends ContainerObject {
                 visible,
                 disabled
             );
-        } else if (elementID === RScriptUIElementID.SWITCH) {
-            (
-                this.getUIElementFromID(elementID)[0] as StateToggle
-            ).display.visible = visible;
         } else {
             if (visible && elementID === RScriptUIElementID.PALETTE) {
                 this.ui.toolbar.palette.setOverrideDefault();
@@ -228,24 +223,20 @@ export default class RScriptEnv extends ContainerObject {
                 this.ui.toolbar.palette.changeNoPairMode();
             }
 
-            let bEnable = true;
-            switch (elementID) {
-                case RScriptUIElementID.ZOOMIN:
-                case RScriptUIElementID.ZOOMOUT:
-                case RScriptUIElementID.RESET:
-                case RScriptUIElementID.UNDO:
-                case RScriptUIElementID.REDO:
-                case RScriptUIElementID.SWAP:
-                case RScriptUIElementID.PIP:
-                case RScriptUIElementID.BASEMARKER:
-                case RScriptUIElementID.MAGICGLUE:
-                    bEnable = false;
-                    break;
-                default:
-                    break;
-            }
-
-            if (bEnable) {
+            // These are part of the customizable toolbar, and we don't want to support selectively
+            // removing items in there
+            const elementsToSkip: string[] = [
+                RScriptUIElementID.ZOOMIN,
+                RScriptUIElementID.ZOOMOUT,
+                RScriptUIElementID.RESET,
+                RScriptUIElementID.UNDO,
+                RScriptUIElementID.REDO,
+                RScriptUIElementID.SWAP,
+                RScriptUIElementID.PIP,
+                RScriptUIElementID.BASEMARKER,
+                RScriptUIElementID.MAGICGLUE
+            ];
+            if (!elementsToSkip.includes(elementID)) {
                 const obj: RScriptUIElement | null = this.getUIElementFromID(elementID)[0];
                 if (obj) {
                     if (obj instanceof DisplayObject) {
@@ -373,6 +364,8 @@ export default class RScriptEnv extends ContainerObject {
                 return this.ui.getConstraintBox(i);
             case RScriptUIElementID.SWITCH:
                 return this.ui.stateToggle;
+            case RScriptUIElementID.FOLDER:
+                return this.ui.folderSwitcher;
             case RScriptUIElementID.TOTALENERGY:
             case RScriptUIElementID.PRIMARY_ENERGY:
                 return this.poseField.primaryScoreDisplay;

--- a/src/eterna/rscript/RScriptEnv.ts
+++ b/src/eterna/rscript/RScriptEnv.ts
@@ -247,6 +247,8 @@ export default class RScriptEnv extends ContainerObject {
 
                     // AMW TODO: this concerns me. Neither DisplayObject nor GameObject
                     // seem to actually implement Enableable...
+                    // JAR Note: Enableable is something that we would add in a subclass of
+                    // DisplayObject or GameObject, but still not sure if this is idiomatic?
                     if ((obj as unknown as Enableable).enabled !== undefined) {
                         (obj as unknown as Enableable).enabled = visible && !disabled;
                     }

--- a/src/eterna/rscript/RScriptUIElement.ts
+++ b/src/eterna/rscript/RScriptUIElement.ts
@@ -22,6 +22,9 @@ export function GetRScriptUIElementBounds(element: RScriptUIElement | null): Rec
 export enum RScriptUIElementID {
     TOGGLETARGET = 'TOGGLETARGET',
     TOGGLENATURAL = 'TOGGLENATURAL',
+    SWITCH = 'SWITCH',
+    FOLDER = 'FOLDER',
+
     ZOOMIN = 'ZOOMIN',
     ZOOMOUT = 'ZOOMOUT',
     RESET = 'RESET',
@@ -31,7 +34,6 @@ export enum RScriptUIElementID {
     HINT = 'HINT',
     PIP = 'PIP',
     FREEZE = 'FREEZE',
-    SWITCH = 'SWITCH',
     BASEMARKER = 'BASEMARKER',
     MAGICGLUE = 'MAGICGLUE',
 

--- a/src/eterna/ui/FolderSwitcher.ts
+++ b/src/eterna/ui/FolderSwitcher.ts
@@ -5,6 +5,8 @@ import {Value, ValueView} from 'signals';
 import {Sprite} from 'pixi.js';
 import Bitmaps from 'eterna/resources/Bitmaps';
 import BitmapManager from 'eterna/resources/BitmapManager';
+import ROPWait from 'eterna/rscript/ROPWait';
+import {RScriptUIElementID} from 'eterna/rscript/RScriptUIElement';
 import GameDropdown from './GameDropdown';
 
 export default class FolderSwitcher extends ContainerObject implements Enableable {
@@ -49,6 +51,7 @@ export default class FolderSwitcher extends ContainerObject implements Enableabl
         this.addObject(this._dropdown, this.container);
         this.regs?.add(this._dropdown.selectedOption.connectNotify((val) => {
             this.selectedFolder.value = this.getFolder(val);
+            ROPWait.notifyClickUI(RScriptUIElementID.FOLDER);
         }));
     }
 


### PR DESCRIPTION
## Summary
This allows for eg the hideui tutorial script command to work with the folding engine display/switcher

## Implementation Notes
Making this change was largely comparing against all places RScriptUIElementID.SWITCH was used and replicating that. Additionally, I did a little cleanup in showHideUI to improve the clarity around elements that skip being hidden

## Testing
Tested ShowUIArrow and #pre-hideui on both FOLDER and SWITCH (due to the tweak in handling of SWITCH and other fallthrough cases).

## Related Issues
Resolves #724
