### PR TITLE
Make tutorial script instructions consistently case insensitive

### DIFF
--- a/src/eterna/rscript/RNAScript.ts
+++ b/src/eterna/rscript/RNAScript.ts
@@ -149,17 +149,17 @@ export default class RNAScript {
         op = op.replace(/\s*$/, '');
 
         // Regex to detect the various commands
-        const textboxRegex = /(Show|Hide)(Textbox|Arrow)(Location|Nucleotide|Energy)?/gi;
-        const highlightRegex = /(Show|Hide)(UI)?Highlight/gi;
-        const uiRegex = /(Show|Hide|Enable|Disable)UI$/gi;
-        const hintRegex = /(Show|Hide)(Paint)?Hint/gi;
-        const waitRegex = /WaitFor(.*)/gi;
-        const preRegex = /#PRE-(.*)/g;
-        const rnaRegex = /^RNA(SetBase|ChangeMode|EnableModification|SetPainter|ChangeState|SetZoom|SetPIP)$/gi;
-        const popPuzzle = /PopPuzzle/;
-        const showMissionScreen = /ShowMissionScreen/;
-        const uiArrow = /(Show|Hide)UIArrow/;
-        const uiTooltip = /(Show|Hide)UITooltip/;
+        const textboxRegex = /(Show|Hide)(Textbox|Arrow)(Location|Nucleotide|Energy)?/i;
+        const highlightRegex = /(Show|Hide)(UI)?Highlight/i;
+        const uiRegex = /(Show|Hide|Enable|Disable)UI$/i;
+        const hintRegex = /(Show|Hide)(Paint)?Hint/i;
+        const waitRegex = /WaitFor(.*)/i;
+        const preRegex = /#PRE-(.*)/i;
+        const rnaRegex = /^RNA(SetBase|ChangeMode|EnableModification|SetPainter|ChangeState|SetZoom|SetPIP)$/i;
+        const popPuzzle = /PopPuzzle/i;
+        const showMissionScreen = /ShowMissionScreen/i;
+        const uiArrow = /(Show|Hide)UIArrow/i;
+        const uiTooltip = /(Show|Hide)UITooltip/i;
 
         let regResult: RegExpExecArray | null;
         if ((regResult = preRegex.exec(op)) != null) {

--- a/src/eterna/rscript/ROPPre.ts
+++ b/src/eterna/rscript/ROPPre.ts
@@ -19,14 +19,14 @@ export default class ROPPre extends RScriptOp {
         super(env);
         this._type = null;
 
-        const disMissionScreenRegex = /DisableMissionScreen/ig;
-        const altPaletteRegex = /UseAlternatePalette/ig;
-        const disableHintRegex = /DisableHintSystem/ig;
-        const hideObjRegex = /HideObjectives/ig;
-        const hideUIRegex = /(Hide|Show|Disable|Enable)UI/ig;
-        const disableRNAMod = /(DisableRNAModification)/ig;
-        const modeRegex = /^(Native|Target)Mode$/ig;
-        const pushPuzzleRegex = /PushPuzzle/;
+        const disMissionScreenRegex = /DisableMissionScreen/i;
+        const altPaletteRegex = /UseAlternatePalette/i;
+        const disableHintRegex = /DisableHintSystem/i;
+        const hideObjRegex = /HideObjectives/i;
+        const hideUIRegex = /(Hide|Show|Disable|Enable)UI/i;
+        const disableRNAMod = /(DisableRNAModification)/i;
+        const modeRegex = /^(Native|Target)Mode$/i;
+        const pushPuzzleRegex = /PushPuzzle/i;
 
         let regResult: RegExpExecArray | null;
         if ((regResult = disMissionScreenRegex.exec(command)) != null) {


### PR DESCRIPTION
## Summary
A number of rscript commands were not case insensitive, even though all of them should be. They are now all case insensitive

## Implementation Notes
The regex /i flag was missing on some newer commands. I also removed /g flags since none of them should match multiple times

## Testing
Manually ran tutorial scripts with showuiarrow and showtextboxnucleotide

## Related Issues
Resolves #737
