### PR TITLE
Improve handled data in beam to puzzlemaker and puzzlemaker autosave

### DIFF
--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -315,7 +315,7 @@ export default abstract class GameMode extends AppMode {
     protected onSetPip(_pipMode: boolean): void {
     }
 
-    protected addPose3D(structureFile: string | File | Blob) {
+    protected addPose3D(structureFile: string | File) {
         const ublk = this.getCurrentUndoBlock(0);
         Assert.assertIsDefined(ublk, "Can't create 3D view - undo state not available");
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -2856,6 +2856,13 @@ export default class PoseEditMode extends GameMode {
     }
 
     private async transferToPuzzlemaker(): Promise<void> {
+        if (this._targetConditions.some((tc) => tc && (
+            Puzzle.isOligoType(tc.type) || Puzzle.isMultistrandType(tc.type)
+        ))) {
+            this.showNotification('Beam to puzzlemaker is not currently supported for puzzles with oligos');
+            return;
+        }
+
         const poseData: SaveStoreItem = [0, this._poses[0].sequence.baseArray];
         const threeDStructure = this._pose3D?.structureFile instanceof File ? {
             name: this._pose3D.structureFile.name,

--- a/src/eterna/pose3D/Pose3DDialog.ts
+++ b/src/eterna/pose3D/Pose3DDialog.ts
@@ -37,11 +37,11 @@ export default class Pose3DDialog extends WindowDialog<void> {
     public readonly baseHovered: Signal<number> = new Signal();
     public readonly sequence: Value<Sequence>;
     public readonly secstruct: Value<SecStruct>;
-    public readonly structureFile: string | File | Blob;
+    public readonly structureFile: string | File;
     public currentColor: RNABase | RNAPaint = RNABase.ADENINE;
 
     constructor(
-        structureFile: string | File | Blob,
+        structureFile: string | File,
         sequence: Sequence,
         secstruct: SecStruct,
         customNumbering: (number | null)[] | undefined
@@ -408,7 +408,7 @@ export default class Pose3DDialog extends WindowDialog<void> {
      * @param structureFile File or path to file to load and check
      * @param expectedLength Expected number of nucleotides in the structure
      */
-    public static async checkModelFile(structureFile: string | File | Blob, expectedLength: number) {
+    public static async checkModelFile(structureFile: string | File, expectedLength: number) {
         const ext = getFileInfo(structureFile).ext;
 
         if (ParserRegistry.isTrajectory(ext)) {

--- a/src/eterna/puzzle/Puzzle.ts
+++ b/src/eterna/puzzle/Puzzle.ts
@@ -58,6 +58,10 @@ export default class Puzzle {
         return (Puzzle.T_OLIGO.indexOf(tcType) >= 0);
     }
 
+    public static isMultistrandType(tcType: TargetType): boolean {
+        return (Puzzle.T_MULTISTRAND.indexOf(tcType) >= 0);
+    }
+
     public static probeTail(seq: Sequence): Sequence | null {
         if (seq == null) {
             return null;
@@ -704,6 +708,7 @@ export default class Puzzle {
 
     private static readonly T_APTAMER: string[] = ['aptamer', 'aptamer+oligo'];
     private static readonly T_OLIGO: string[] = ['oligo', 'aptamer+oligo'];
+    private static readonly T_MULTISTRAND: string[] = ['multistrand'];
 
     private static readonly DEFAULT_MISSION_TEXT: string = 'Match the desired RNA shape!';
 }


### PR DESCRIPTION
## Summary
- Show a message instead of crashing when trying to beam with oligos
- Beam 3D structure
- Beam locks
- Beam custom layout
- Autosave 3D structure
- Autosave locks
- Autosave custom layout
- Autosave molecule
- Autosave folding engine
  - Promote EternaFold to default
  - Remove EternaFold notice

## Implementation Notes
There is some weirdness around data being pose-dependent vs not, coming from pose vs separate undo arrays, etc. I tried to be as consistent with the current code as possible

## Testing
Tried beam/autosave load for each feature

## Related Issues
Resolves #726
Resolves #174
