### PR TITLE
Refactor/extract scripting api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "core-js": "^3.13.1",
         "dompurify": "^2.2.9",
         "eterna-chat-wrapper": "https://github.com/eternagame/eterna-chat-wrapper/archive/b7c15ba65073d99a2514009e1b4657c8dca3517d.tar.gz",
+        "eternajs-folding-engines": "github:eternagame/eternajs-folding-engines#cad1c24dba21a12b3219648b866e1042a64d8403",
         "is-mobile": "^3.0.0",
         "js-polyfills": "^0.1.43",
         "libtess": "^1.2.2",
@@ -6817,7 +6818,7 @@
     "node_modules/eternajs-folding-engines": {
       "version": "1.9.1",
       "resolved": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#cad1c24dba21a12b3219648b866e1042a64d8403",
-      "integrity": "sha512-PLqecDhDFD6LS/l2Q2eaKhtrwZMtZFfWkhmoOk/+ekrCryKwpTNxPRVoj4fgfW8gNcaOGps6u+RmHyTKSuAeJw==",
+      "integrity": "sha512-cPYvuIzDyjyxxtxCk9TFxItWafmW40fFeKWr6QpoY8q5G7THYKm6ajz3UH34D3YuBz/lPrlgim7Wm0SjWStLSA==",
       "optional": true
     },
     "node_modules/eventemitter3": {
@@ -19106,7 +19107,7 @@
     },
     "eternajs-folding-engines": {
       "version": "git+ssh://git@github.com/eternagame/eternajs-folding-engines.git#cad1c24dba21a12b3219648b866e1042a64d8403",
-      "integrity": "sha512-PLqecDhDFD6LS/l2Q2eaKhtrwZMtZFfWkhmoOk/+ekrCryKwpTNxPRVoj4fgfW8gNcaOGps6u+RmHyTKSuAeJw==",
+      "integrity": "sha512-cPYvuIzDyjyxxtxCk9TFxItWafmW40fFeKWr6QpoY8q5G7THYKm6ajz3UH34D3YuBz/lPrlgim7Wm0SjWStLSA==",
       "from": "eternajs-folding-engines@github:eternagame/eternajs-folding-engines#cad1c24dba21a12b3219648b866e1042a64d8403",
       "optional": true
     },

--- a/src/eterna/eternaScript/FoldingAPI.ts
+++ b/src/eterna/eternaScript/FoldingAPI.ts
@@ -6,7 +6,17 @@ import Sequence from 'eterna/rnatypes/Sequence';
 import {ExternalInterfaceCtx} from 'eterna/util/ExternalInterface';
 import {Assert} from 'flashbang';
 
-export default class FoldingContextAPI {
+/**
+ * An EternaScript API exposing all functions that handle folding an arbitrary
+ * RNA sequence, and aren't dependent on what's the RNA in the puzzle.
+ *
+ * It adds itself to an existing script API (`ExternalInterfaceCtx`) from
+ * `this.registerToScriptInterface`.
+ *
+ * Note: The API in this class is still affected by the selected folder
+ * and the pseudoknot mode of the puzzle - just not the sequence.
+ */
+export default class FoldingAPI {
     private readonly _getFolder: () => Folder | null;
     private readonly _getIsPseudoknot: () => boolean;
 
@@ -34,7 +44,9 @@ export default class FoldingContextAPI {
                     return null;
                 }
                 const seqArr: Sequence = Sequence.fromSequenceString(seq);
-                const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint, this._isPseudoknot);
+                const folded: SecStruct | null = this._folder.foldSequence(
+                    seqArr, null, constraint, this._isPseudoknot
+                );
                 Assert.assertIsDefined(folded);
                 return folded.getParenthesis(null, this._isPseudoknot);
             });

--- a/src/eterna/eternaScript/SelectFolderAPI.ts
+++ b/src/eterna/eternaScript/SelectFolderAPI.ts
@@ -1,0 +1,13 @@
+import {ExternalInterfaceCtx} from 'eterna/util/ExternalInterface';
+
+/**
+ * Adds the ability to modify the folder (via its name) to the EternaScript API.
+*/
+export default function addSelectFolderAPIToInterface({selectFolder, scriptInterface}: {
+    selectFolder: (folderName: string) => boolean,
+    scriptInterface: ExternalInterfaceCtx,
+}) {
+    scriptInterface.addCallback(
+        'select_folder', (folderName: string): boolean => selectFolder(folderName)
+    );
+}

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -79,6 +79,7 @@ import NuPACK from 'eterna/folding/NuPACK';
 import PasteStructureDialog from 'eterna/ui/PasteStructureDialog';
 import ConfirmTargetDialog from 'eterna/ui/ConfirmTargetDialog';
 import FoldingContextScriptAPI from 'eterna/eternaScript/FoldingAPI';
+import addSelectFolderAPIToInterface from 'eterna/eternaScript/SelectFolderAPI';
 import GameMode from '../GameMode';
 import SubmittingDialog from './SubmittingDialog';
 import SubmitPoseDialog from './SubmitPoseDialog';
@@ -1276,9 +1277,10 @@ export default class PoseEditMode extends GameMode {
         }).registerToScriptInterface(this._scriptInterface);
 
         if (this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL) {
-            this._scriptInterface.addCallback(
-                'select_folder', (folderName: string): boolean => this.selectFolder(folderName)
-            );
+            addSelectFolderAPIToInterface({
+                selectFolder: this.selectFolder,
+                scriptInterface: this._scriptInterface
+            });
 
             this._scriptInterface.addCallback('load_parameters_from_buffer', (_str: string): boolean => {
                 log.info('TODO: load_parameters_from_buffer');

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -78,6 +78,7 @@ import {FederatedPointerEvent} from '@pixi/events';
 import NuPACK from 'eterna/folding/NuPACK';
 import PasteStructureDialog from 'eterna/ui/PasteStructureDialog';
 import ConfirmTargetDialog from 'eterna/ui/ConfirmTargetDialog';
+import FoldingContextScriptAPI from 'eterna/eternaScript/FoldingAPI';
 import GameMode from '../GameMode';
 import SubmittingDialog from './SubmittingDialog';
 import SubmitPoseDialog from './SubmitPoseDialog';
@@ -88,7 +89,6 @@ import ViewSolutionOverlay from '../DesignBrowser/ViewSolutionOverlay';
 import {PuzzleEditPoseData} from '../PuzzleEdit/PuzzleEditMode';
 import {DesignCategory} from '../DesignBrowser/DesignBrowserMode';
 import VoteProcessor from '../DesignBrowser/VoteProcessor';
-import FoldingContextScriptAPI from './ScriptsApi';
 
 export interface PoseEditParams {
     isReset?: boolean;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1272,9 +1272,8 @@ export default class PoseEditMode extends GameMode {
         new FoldingContextScriptAPI({
             getFolder: () => this._folder,
             getIsPseudoknot: () => Boolean(this._targetConditions && this._targetConditions[0]
-                    && this._targetConditions[0]['type'] === 'pseudoknot'),
-            scriptInterface: this._scriptInterface
-        }).registerToScriptInterface();
+                    && this._targetConditions[0]['type'] === 'pseudoknot')
+        }).registerToScriptInterface(this._scriptInterface);
 
         if (this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL) {
             this._scriptInterface.addCallback(

--- a/src/eterna/mode/PoseEdit/ScriptsApi.ts
+++ b/src/eterna/mode/PoseEdit/ScriptsApi.ts
@@ -1,0 +1,164 @@
+import EPars from 'eterna/EPars';
+import Folder, {SuboptEnsembleResult} from 'eterna/folding/Folder';
+import DotPlot from 'eterna/rnatypes/DotPlot';
+import SecStruct from 'eterna/rnatypes/SecStruct';
+import Sequence from 'eterna/rnatypes/Sequence';
+import {ExternalInterfaceCtx} from 'eterna/util/ExternalInterface';
+import {Assert} from 'flashbang';
+
+export default class FoldingContextAPI {
+    private readonly _scriptInterface: ExternalInterfaceCtx;
+    private readonly _getFolder: () => Folder | null;
+    private readonly _getIsPseudoknot: () => boolean;
+
+    private get _folder(): Folder | null {
+        return this._getFolder();
+    }
+
+    private get _isPseudoknot(): boolean {
+        return this._getIsPseudoknot();
+    }
+
+    constructor(params: { scriptInterface: ExternalInterfaceCtx, getFolder: () => Folder, getIsPseudoknot: () => boolean }) {
+        this._getIsPseudoknot = params.getIsPseudoknot;
+        this._getFolder = params.getFolder;
+        this._scriptInterface = params.scriptInterface;
+    }
+
+    public registerToScriptInterface() {
+        this._scriptInterface.addCallback('current_folder', (): string | null => (
+            this._folder ? this._folder.name : null
+        ));
+
+        this._scriptInterface.addCallback('fold',
+            (seq: string, constraint: string | null = null): string | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                const seqArr: Sequence = Sequence.fromSequenceString(seq);
+                const pseudoknots = this._targetConditions && this._targetConditions[0]
+                    && this._targetConditions[0]['type'] === 'pseudoknot';
+                const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint, pseudoknots);
+                Assert.assertIsDefined(folded);
+                return folded.getParenthesis(null, pseudoknots);
+            });
+
+        this._scriptInterface.addCallback('fold_with_binding_site',
+            (seq: string, site: number[], bonus: number): string | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                const seqArr: Sequence = Sequence.fromSequenceString(seq);
+                const folded: SecStruct | null = this._folder.foldSequenceWithBindingSite(
+                    seqArr, null, site, Math.floor(bonus * 100), 2.5
+                );
+                if (folded === null) {
+                    return null;
+                }
+                return folded.getParenthesis();
+            });
+
+        this._scriptInterface.addCallback('energy_of_structure', (seq: string, secstruct: string): number | null => {
+            if (this._folder === null) {
+                return null;
+            }
+            const seqArr: Sequence = Sequence.fromSequenceString(seq);
+            const structArr: SecStruct = SecStruct.fromParens(secstruct);
+            const freeEnergy = (this._targetConditions && this._targetConditions[0]
+                && this._targetConditions[0]['type'] === 'pseudoknot')
+                ? this._folder.scoreStructures(seqArr, structArr, true)
+                : this._folder.scoreStructures(seqArr, structArr);
+            return 0.01 * freeEnergy;
+        });
+
+        // AMW: still give number[] back because external scripts may rely on it
+        this._scriptInterface.addCallback('pairing_probabilities',
+            (seq: string, secstruct: string | null = null): number[] | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                const seqArr: Sequence = Sequence.fromSequenceString(seq);
+                let folded: SecStruct | null;
+                if (secstruct) {
+                    folded = SecStruct.fromParens(secstruct);
+                } else {
+                    folded = this._folder.foldSequence(seqArr, null, null);
+                    if (folded === null) {
+                        return null;
+                    }
+                }
+                const pp: DotPlot | null = this._folder.getDotPlot(seqArr, folded);
+                Assert.assertIsDefined(pp);
+                return pp.data;
+            });
+
+        this._scriptInterface.addCallback('subopt_single_sequence',
+            (
+                seq: string, kcalDelta: number,
+                pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
+            ): SuboptEnsembleResult | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                // now get subopt stuff
+                const seqArr: Sequence = Sequence.fromSequenceString(seq);
+                return this._folder.getSuboptEnsembleNoBindingSite(seqArr,
+                    kcalDelta, pseudoknotted, temp);
+            });
+
+        this._scriptInterface.addCallback('subopt_oligos',
+            (
+                seq: string, oligoStrings: string[], kcalDelta: number,
+                pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
+            ): SuboptEnsembleResult | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                // make the sequence string from the oligos
+                let newSequence: string = seq;
+                for (let oligoIndex = 0; oligoIndex < oligoStrings.length; oligoIndex++) {
+                    const oligoSequence: string = oligoStrings[oligoIndex];
+                    newSequence = `${newSequence}&${oligoSequence}`;
+                }
+
+                // now get subopt stuff
+                const seqArr: Sequence = Sequence.fromSequenceString(newSequence);
+                return this._folder.getSuboptEnsembleWithOligos(seqArr,
+                    oligoStrings, kcalDelta, pseudoknotted, temp);
+            });
+
+        this._scriptInterface.addCallback('cofold',
+            (
+                seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null
+            ): string | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                const len: number = seq.length;
+                const cseq = `${seq}&${oligo}`;
+                const seqArr: Sequence = Sequence.fromSequenceString(cseq);
+                const folded: SecStruct | null = this._folder.cofoldSequence(
+                    seqArr, null, Math.floor(malus * 100), constraint
+                );
+                if (folded === null) {
+                    return null;
+                }
+                return `${folded.slice(0, len).getParenthesis()
+                }&${folded.slice(len).getParenthesis()}`;
+            });
+
+        this._scriptInterface.addCallback('get_defect',
+            (
+                seq: string, secstruct: string, pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
+            ): number | null => {
+                if (this._folder === null) {
+                    return null;
+                }
+                return this._folder.getDefect(
+                    Sequence.fromSequenceString(seq),
+                    SecStruct.fromParens(secstruct),
+                    temp, pseudoknotted
+                );
+            });
+    }
+}

--- a/src/eterna/mode/PoseEdit/ScriptsApi.ts
+++ b/src/eterna/mode/PoseEdit/ScriptsApi.ts
@@ -36,11 +36,9 @@ export default class FoldingContextAPI {
                     return null;
                 }
                 const seqArr: Sequence = Sequence.fromSequenceString(seq);
-                const pseudoknots = this._targetConditions && this._targetConditions[0]
-                    && this._targetConditions[0]['type'] === 'pseudoknot';
-                const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint, pseudoknots);
+                const folded: SecStruct | null = this._folder.foldSequence(seqArr, null, constraint, this._isPseudoknot);
                 Assert.assertIsDefined(folded);
-                return folded.getParenthesis(null, pseudoknots);
+                return folded.getParenthesis(null, this._isPseudoknot);
             });
 
         this._scriptInterface.addCallback('fold_with_binding_site',
@@ -64,9 +62,7 @@ export default class FoldingContextAPI {
             }
             const seqArr: Sequence = Sequence.fromSequenceString(seq);
             const structArr: SecStruct = SecStruct.fromParens(secstruct);
-            const freeEnergy = (this._targetConditions && this._targetConditions[0]
-                && this._targetConditions[0]['type'] === 'pseudoknot')
-                ? this._folder.scoreStructures(seqArr, structArr, true)
+            const freeEnergy = this._isPseudoknot ? this._folder.scoreStructures(seqArr, structArr, true)
                 : this._folder.scoreStructures(seqArr, structArr);
             return 0.01 * freeEnergy;
         });

--- a/src/eterna/mode/PoseEdit/ScriptsApi.ts
+++ b/src/eterna/mode/PoseEdit/ScriptsApi.ts
@@ -7,7 +7,6 @@ import {ExternalInterfaceCtx} from 'eterna/util/ExternalInterface';
 import {Assert} from 'flashbang';
 
 export default class FoldingContextAPI {
-    private readonly _scriptInterface: ExternalInterfaceCtx;
     private readonly _getFolder: () => Folder | null;
     private readonly _getIsPseudoknot: () => boolean;
 
@@ -19,18 +18,17 @@ export default class FoldingContextAPI {
         return this._getIsPseudoknot();
     }
 
-    constructor(params: { scriptInterface: ExternalInterfaceCtx, getFolder: () => Folder, getIsPseudoknot: () => boolean }) {
+    constructor(params: { getFolder: () => Folder, getIsPseudoknot: () => boolean }) {
         this._getIsPseudoknot = params.getIsPseudoknot;
         this._getFolder = params.getFolder;
-        this._scriptInterface = params.scriptInterface;
     }
 
-    public registerToScriptInterface() {
-        this._scriptInterface.addCallback('current_folder', (): string | null => (
+    public registerToScriptInterface(scriptInterface: ExternalInterfaceCtx) {
+        scriptInterface.addCallback('current_folder', (): string | null => (
             this._folder ? this._folder.name : null
         ));
 
-        this._scriptInterface.addCallback('fold',
+        scriptInterface.addCallback('fold',
             (seq: string, constraint: string | null = null): string | null => {
                 if (this._folder === null) {
                     return null;
@@ -41,7 +39,7 @@ export default class FoldingContextAPI {
                 return folded.getParenthesis(null, this._isPseudoknot);
             });
 
-        this._scriptInterface.addCallback('fold_with_binding_site',
+        scriptInterface.addCallback('fold_with_binding_site',
             (seq: string, site: number[], bonus: number): string | null => {
                 if (this._folder === null) {
                     return null;
@@ -56,7 +54,7 @@ export default class FoldingContextAPI {
                 return folded.getParenthesis();
             });
 
-        this._scriptInterface.addCallback('energy_of_structure', (seq: string, secstruct: string): number | null => {
+        scriptInterface.addCallback('energy_of_structure', (seq: string, secstruct: string): number | null => {
             if (this._folder === null) {
                 return null;
             }
@@ -68,7 +66,7 @@ export default class FoldingContextAPI {
         });
 
         // AMW: still give number[] back because external scripts may rely on it
-        this._scriptInterface.addCallback('pairing_probabilities',
+        scriptInterface.addCallback('pairing_probabilities',
             (seq: string, secstruct: string | null = null): number[] | null => {
                 if (this._folder === null) {
                     return null;
@@ -88,7 +86,7 @@ export default class FoldingContextAPI {
                 return pp.data;
             });
 
-        this._scriptInterface.addCallback('subopt_single_sequence',
+        scriptInterface.addCallback('subopt_single_sequence',
             (
                 seq: string, kcalDelta: number,
                 pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
@@ -102,7 +100,7 @@ export default class FoldingContextAPI {
                     kcalDelta, pseudoknotted, temp);
             });
 
-        this._scriptInterface.addCallback('subopt_oligos',
+        scriptInterface.addCallback('subopt_oligos',
             (
                 seq: string, oligoStrings: string[], kcalDelta: number,
                 pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
@@ -123,7 +121,7 @@ export default class FoldingContextAPI {
                     oligoStrings, kcalDelta, pseudoknotted, temp);
             });
 
-        this._scriptInterface.addCallback('cofold',
+        scriptInterface.addCallback('cofold',
             (
                 seq: string, oligo: string, malus: number = 0.0, constraint: string | null = null
             ): string | null => {
@@ -143,7 +141,7 @@ export default class FoldingContextAPI {
                 }&${folded.slice(len).getParenthesis()}`;
             });
 
-        this._scriptInterface.addCallback('get_defect',
+        scriptInterface.addCallback('get_defect',
             (
                 seq: string, secstruct: string, pseudoknotted: boolean, temp: number = EPars.DEFAULT_TEMPERATURE
             ): number | null => {


### PR DESCRIPTION
<!--
    Thank you for submitting a pull request! We appreciate your time and effort.
    Please make sure you have read our contributing guidelines before posting a PR
    https://github.com/eternagame/.github/blob/main/CONTRIBUTING.md

    Please title your PR according to the conventional commits standard - see the contributing
    guidelines for more info. Additionally, help us review your changes and provide a record for
    later reference by providing the information below. Note that the PR description will be used
    as the commit description when the PR is merged, so please keep it up to date as you make any changes!
-->

## Summary
In order to prepare the ground for creating a new EternaJS app that just exposes the folding API without any additional state (which would allow fixing https://github.com/eternagame/eternagame.org/issues/378), and in order to just simplify PoseEditMode, this PR extracts logic related the to the folding scripting (booster) API from PoseEditMode to a new class (/function), which would have very few dependencies.

## Implementation Notes
Moved the code responsible for exposing the folding API (which only depends on the folding context, i.e read-only access to `this._folder` and understanding whether or not we are in psuedoknot mode) from PoseEditMode.ts to a separate ScriptsApi.ts flie (name WIP)

## Testing
I currently only ran `document.getElementById("maingame").fold("AUGGGGGGGGGGGGGGGGGGGGCCCCCCCCCCCCCCCCCCCC") ` after running the script evaluator (in order to load the script interface)`.

## Related Issues
Preparations for fixing https://github.com/eternagame/eternagame.org/issues/378

## TODO
Blocking merge:
* ~Rename the class and the file name~
* ~Probably change the class into a function~ - I decided against it.
* ~Move the file~
* ~Make eslint not angry~
* Testing

Direct Follow-Up / maybe this PR
* ~extract setting the folding engine as well~

Later
* Extract the rest of the scripting API to helper classes / functions

## Notes / Questions for CR
Notes
* It's still WIP, but I'd appriciate an early review to make sure I'm on the right track
* You should probably review this commit by commit, they are much more indicative than the diff

Questions
* Do you think the idea with `_getFolder` and `_getIsPseudoknot` make sense? I couldn't find a better way without a) making a `SwitchableFolder` proxy object or b) giving this class access to the entire PoseEditMode (now that I think about it, we could define an interface containing `folder` and `isPseudoknot`... but I think it's better to just pass these 2, although I haven't done typescript in years)
    * Well apparently there is a `SwitchableFolder` - it's `FolderSwitcher`. Should I use it for this? Or the getter thing?
        * `FolderSwitcher` is coupled to pixi and the GUI, so I think I'm satisfied with the current way.
    * And is `isPseudoknot` ever going to change?
* About pseudoknots - what does it mean to be in pseudoknots mode? That we look at tertiary structure when folding? This makes `Lib.fold` behave differently between different puzzles - but now it will also (or maybe has) behave differently between the editor and the scripts page and the game
* Where should I put this file? I put this in `eterna/eternaScript`, but `ExternalInterfaceCtx` should probably also sit there - however, I'm not sure if they should sit together - the code I moved is "user" code using the interface context, while the interface context itself is more of a "library" thing. Should I move it there as well in a follow up PR?
