### PR TITLE
Support specbox in puzzlemaker

### DIFF
--- a/src/eterna/ui/toolbar/Toolbar.ts
+++ b/src/eterna/ui/toolbar/Toolbar.ts
@@ -556,7 +556,7 @@ export default class Toolbar extends ContainerObject {
 
         // Info
         this.viewSolutionsButton = this.setupButton(viewSolutionsButtonProps, canViewDesigns);
-        this.specButton = this.setupButton(specButtonProps, !isPuzzlemaker);
+        this.specButton = this.setupButton(specButtonProps);
         this.submitButton = this.setupButton(
             isPuzzlemaker ? submitPuzzleButtonProps : submitSolutionButtonProps,
             isSubmittable


### PR DESCRIPTION
## Summary
Being able to see the dot plot and additional specs in puzzlemaker can be useful in a variety of cases
be it to help solve an in-progress puzzle, work on a "partial" extracted from a puzzle, or
otherwise perform analysis with a free-form modifiable structure.

This is particularly important for the upcoming integration of RibonanzaNet, where we want to encourage players
to experiment with the behavior of the model, and both the dot plot and upcoming eF1 metrics will be important
for this

## Testing
Opened specbox in puzzlemaker + made changes to puzzle

## Related Issues
Split off from #748
