### PR TITLE
Consistently disable energies when unavailable

### DIFF
--- a/src/eterna/folding/Contrafold.ts
+++ b/src/eterna/folding/Contrafold.ts
@@ -46,7 +46,7 @@ export default class ContraFold extends Folder<true> {
         return true;
     }
 
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(): boolean {
         return true;
     }
 

--- a/src/eterna/folding/Eternafold.ts
+++ b/src/eterna/folding/Eternafold.ts
@@ -46,7 +46,7 @@ export default class EternaFold extends Folder<true> {
         return true;
     }
 
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(): boolean {
         return true;
     }
 

--- a/src/eterna/folding/EternafoldThreshknot.ts
+++ b/src/eterna/folding/EternafoldThreshknot.ts
@@ -39,6 +39,8 @@ export default class EternaFoldThreshknot extends EternaFold {
     }
 
     public canScoreStructures() {
+        // This would return energies for the structure omitting pseudoknots, so the values
+        // for a pseudoknotted structure would be wrong
         return false;
     }
 

--- a/src/eterna/folding/EternafoldThreshknot.ts
+++ b/src/eterna/folding/EternafoldThreshknot.ts
@@ -38,6 +38,10 @@ export default class EternaFoldThreshknot extends EternaFold {
         return true;
     }
 
+    public canScoreStructures() {
+        return false;
+    }
+
     /* override */
     /**
      * This overrides Eternafold's default foldSequenceImpl implementation with

--- a/src/eterna/folding/Folder.ts
+++ b/src/eterna/folding/Folder.ts
@@ -39,7 +39,7 @@ export default abstract class Folder<Sync extends boolean = boolean> {
         return this._cache.get(keyStr);
     }
 
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(_pseudoknots: boolean): boolean {
         return false;
     }
 

--- a/src/eterna/folding/LinearFoldBase.ts
+++ b/src/eterna/folding/LinearFoldBase.ts
@@ -59,7 +59,7 @@ export default abstract class LinearFoldBase extends Folder<true> {
         return true;
     }
 
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(): boolean {
         return true;
     }
 

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -244,6 +244,7 @@ export default class NuPACK extends Folder<true> {
 
     /* override */
     public canScoreStructures(pseudoknots: boolean): boolean {
+        // See https://github.com/eternagame/EternaJS/issues/654
         return pseudoknots === false;
     }
 

--- a/src/eterna/folding/NuPACK.ts
+++ b/src/eterna/folding/NuPACK.ts
@@ -243,8 +243,8 @@ export default class NuPACK extends Folder<true> {
     }
 
     /* override */
-    public get canScoreStructures(): boolean {
-        return true;
+    public canScoreStructures(pseudoknots: boolean): boolean {
+        return pseudoknots === false;
     }
 
     /* override */

--- a/src/eterna/folding/RNNet.ts
+++ b/src/eterna/folding/RNNet.ts
@@ -24,7 +24,7 @@ export default class RNNet extends Folder<false> {
         return true;
     }
 
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(): boolean {
         return false;
     }
 

--- a/src/eterna/folding/Vienna.ts
+++ b/src/eterna/folding/Vienna.ts
@@ -100,7 +100,7 @@ export default class Vienna extends Folder<true> {
         return true;
     }
 
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(): boolean {
         return true;
     }
 

--- a/src/eterna/folding/Vienna2.ts
+++ b/src/eterna/folding/Vienna2.ts
@@ -105,7 +105,7 @@ export default class Vienna2 extends Folder<true> {
     }
 
     /* override */
-    public get canScoreStructures(): boolean {
+    public canScoreStructures(): boolean {
         return true;
     }
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -769,14 +769,8 @@ export default class PoseEditMode extends GameMode {
             this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL
         );
         this._folderSwitcher.selectedFolder.connectNotify((folder) => {
-            if (folder.canScoreStructures) {
-                for (const pose of this._poses) {
-                    pose.scoreFolder = folder;
-                }
-            } else {
-                for (const pose of this._poses) {
-                    pose.scoreFolder = null;
-                }
+            for (const pose of this._poses) {
+                pose.scoreFolder = folder;
             }
 
             this.onChangeFolder();

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -345,14 +345,8 @@ export default class PuzzleEditMode extends GameMode {
         }
         this._folderSwitcher = this._modeBar.addFolderSwitcher((folder) => this.canUseFolder(folder), defaultFolder);
         this._folderSwitcher.selectedFolder.connectNotify(async (folder) => {
-            if (folder.canScoreStructures) {
-                for (const pose of this._poses) {
-                    pose.scoreFolder = folder;
-                }
-            } else {
-                for (const pose of this._poses) {
-                    pose.scoreFolder = null;
-                }
+            for (const pose of this._poses) {
+                pose.scoreFolder = folder;
             }
 
             for (const pose of this._poses) {
@@ -1211,6 +1205,7 @@ export default class PuzzleEditMode extends GameMode {
             const lock: boolean[] | undefined = this._poses[ii].puzzleLocks;
             const bindingSite = this._poses[ii].molecularBindingSite;
             const customLayout = this._poses[ii].customLayout;
+            this._poses[ii].pseudoknotted = pseudoknots;
 
             if (this._stackLevel >= 0) {
                 if (

--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -3227,16 +3227,12 @@ export default class Pose2D extends ContainerObject implements Updatable {
         return this._colorblindTheme;
     }
 
-    public set scoreFolder(folder: Folder | null) {
+    public set scoreFolder(folder: Folder) {
         if (this._scoreFolder !== folder) {
             this._scoreFolder = folder;
             // this.showTotalEnergy = this._showTotalEnergy;
             this.generateScoreNodes();
         }
-    }
-
-    public get scoreFolder(): Folder | null {
-        return this._scoreFolder;
     }
 
     public baseShiftWithCommand(command: number, index: number): void {
@@ -4130,11 +4126,11 @@ export default class Pose2D extends ContainerObject implements Updatable {
     private updateScoreNodeGui(): void {
         this._scoreNodeIndex = -1;
 
-        if (this._pseudoknotted) {
-            // See https://github.com/eternagame/EternaJS/issues/654
+        if (!this._scoreFolder || !this._scoreFolder.canScoreStructures(this.pseudoknotted)) {
             this._poseField.disableEnergyGui('Unavailable');
             return;
         }
+        this._poseField.enableEnergyGui();
 
         if (this._scoreNodes != null) {
             let totalScore = 0;
@@ -4170,7 +4166,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 }
             }
 
-            if (this._pseudoknotted && this._scoreFolder !== null) {
+            if (this._pseudoknotted) {
                 totalScore = Math.round(this._scoreFolder.scoreStructures(
                     this._sequence, this._pairs.getSatisfiedPairs(this._sequence), true
                 ));
@@ -4261,7 +4257,8 @@ export default class Pose2D extends ContainerObject implements Updatable {
         this._scoreNodeHighlight.clear();
         this.clearEnergyHighlights();
 
-        if (this._scoreFolder == null
+        if (!this._scoreFolder
+            || !this._scoreFolder.canScoreStructures(this.pseudoknotted)
             || this._sequence == null
             || this._sequence.length === 0
             || this._pairs == null
@@ -4522,7 +4519,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
     // Score display nodes
     private _scoreNodes: ScoreDisplayNode[] | null;
     private _scoreTexts: Sprite[] | null;
-    private _scoreFolder: Folder | null;
+    private _scoreFolder?: Folder;
     private _scoreNodeIndex: number = -1;
     private _lastScoreNodeIndex: number = -1;
     private _scoreNodeHighlight: Graphics;

--- a/src/eterna/pose2D/PoseField.ts
+++ b/src/eterna/pose2D/PoseField.ts
@@ -293,6 +293,10 @@ export default class PoseField extends ContainerObject implements KeyboardListen
         this.updateEnergyContainer();
     }
 
+    public enableEnergyGui() {
+        this._energyDisabled = false;
+    }
+
     // Pointer to function that needs to be called in a GameMode to have access to appropriate state
     private _getEnergyDelta: () => number;
 
@@ -323,7 +327,7 @@ export default class PoseField extends ContainerObject implements KeyboardListen
             'Natural/Target Delta',
             `${Math.round(delta) / 100} kcal`
         );
-        this._deltaScoreEnergyDisplay.visible = (this._showTotalEnergy && this.pose.scoreFolder != null);
+        this._deltaScoreEnergyDisplay.visible = this._showTotalEnergy;
         this.updateEnergyContainer();
     }
 
@@ -333,11 +337,11 @@ export default class PoseField extends ContainerObject implements KeyboardListen
 
     public set showTotalEnergy(show: boolean) {
         this._showTotalEnergy = show;
-        this._primaryScoreEnergyDisplay.visible = (show && this.pose.scoreFolder != null);
+        this._primaryScoreEnergyDisplay.visible = show;
         this._secondaryScoreEnergyDisplay.visible = (
-            show && this.pose.scoreFolder != null && this._secondaryScoreEnergyDisplay.hasText
+            show && this._secondaryScoreEnergyDisplay.hasText
         );
-        this._deltaScoreEnergyDisplay.visible = show && this.pose.scoreFolder != null;
+        this._deltaScoreEnergyDisplay.visible = show;
         this.updateEnergyContainer();
     }
 


### PR DESCRIPTION
## Summary
* Puzzlemaker now properly shows energies as disabled for engines that cant score with pseudoknots
* Energies are noted as unavailable instead of hidden for both pknot cases as well as engines that cant score
* Switching between engines with and without energies available now consistently enables and disables energies

## Implementation Notes
Instead of conditionally setting the scoreFolder based on canScoreStructures and then checking the pseudoknotted case,
canScoreStructures now takes a parameter for whether or not pknots are enabled, and skipping computations
is now handled just within Pose2D. This avoids logic for whether an engine can score being split in multiple
places.

## Related Issues
Raised as part of #748
