### PR TITLE
Improve sourcemap behavior

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -37,8 +37,6 @@ function getEngineLocation() {
 }
 
 module.exports = {
-    devtool: "inline-source-map",
-    
     entry: {
         main: ['core-js/stable', 'regenerator-runtime/runtime', "./src/eterna/index.ts"],
         vendor: vendorDependencies

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,6 +5,8 @@ const path = require('path');
 module.exports = merge(common, {
     mode: 'development',
 
+    devtool: "eval-source-map",
+
     output: {
         path: path.resolve(__dirname + "/dist/dev"),
     },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -13,6 +13,8 @@ const mobile_app = ParseBool(process.env.MOBILE_APP);
 module.exports = merge(common, {
     mode: 'production',
 
+    devtool: "source-map",
+
     output: {
         path: path.resolve(__dirname + "/dist/prod"),
         publicPath: mobile_app ? '' : '/eternajs/dist/prod/'


### PR DESCRIPTION
Previously, we always used inline-source-map for generating sourcemaps. Now in prod we use source-map to split the sourcemaps into separate files (which significantly reduces our bundle size) and in dev we use eval-source-map, which is faster
