### PR TITLE
Support async folding operations in EternaScript

### DIFF
--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -656,7 +656,7 @@ export default class UndoBlock {
         if (currDotPlot === undefined) {
             let dotArray: DotPlot | null;
             if (sync) {
-                if (!folder.isSync()) throw new Error('Tried to use synchronous folder asynchronously');
+                if (!folder.isSync()) throw new Error('Tried to use asynchronous folder synchronously');
                 dotArray = folder.getDotPlot(
                     this.sequence, this.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots),
                     EPars.DEFAULT_TEMPERATURE, pseudoknots
@@ -709,7 +709,7 @@ export default class UndoBlock {
                 if (this.getPairs(ii, pseudoknots).length === 0) {
                     let pairs: SecStruct | null;
                     if (sync) {
-                        if (!folder.isSync()) throw new Error('Tried to use synchronous folder asynchronously');
+                        if (!folder.isSync()) throw new Error('Tried to use asynchronous folder synchronously');
                         pairs = folder.foldSequence(this.sequence, null, null, pseudoknots, ii);
                     } else {
                         // eslint-disable-next-line no-await-in-loop
@@ -722,7 +722,7 @@ export default class UndoBlock {
                 if (this.getParam(UndoBlockParam.DOTPLOT, ii, pseudoknots) == null) {
                     let dotTempArray: DotPlot | null;
                     if (sync) {
-                        if (!folder.isSync()) throw new Error('Tried to use synchronous folder asynchronously');
+                        if (!folder.isSync()) throw new Error('Tried to use asynchronous folder synchronously');
                         dotTempArray = folder.getDotPlot(
                             this.sequence,
                             this.getPairs(ii, pseudoknots),


### PR DESCRIPTION
## Summary
* There are now new async versions of EternaScript methods which trigger folding operations. This allows usage with async-only folding engines, as well as allowing scripts to use more efficient or user friendly behavior that is only available when folding happens async
* When calling any EternaScript getter or setter, we now verify that there are no asyncronous folding operations in process to avoid getting out of sync. This could happen already even with the existing syncronous APIs, as a user could trigger an asynchronous fold and then a script could trigger a synchronous fold before the async fold finishes.
* Fixed inverted error messages for sync/async behavior in specbox updates
* We now wait until the specbox is fully updated before unlocking the UI after a fold (and run synchronously if triggered from a synchronous script call)
* Added missing sync check to select_folder

## Implementation Notes
There was some ambiguity around whether the eternascript setters or getters should be async and how much actually needs to be completed before these methods returned. It seemed most straightforward and consistent to have setters wait until all UI update operations are finished, treating them as "please trigger this update, and let me know once it is done". This also makes it clear for how scripts indicate that they allow async folding to happen (opting-in to better behavior even if sync folding is not strictly required) .

While I was here
* Reorganized the eternascript callbacks into a more natural order
* Removed set_design_title and load_parameters_from_buffer which I verified no one is using

## Testing
With the specbox open and closed
* Made normal mutations with eftk and rnnss
* Ran sync methods with eftk and rnnss
* Ran async methods with eftk and rnnss, including serial operations with and without awaiting

## Related Issues
Followon to #748 