### PR TITLE
Notify the user if a tutorial requires boosters but they are not unlocked

### DIFF
--- a/src/eterna/rscript/RScriptEnv.ts
+++ b/src/eterna/rscript/RScriptEnv.ts
@@ -287,7 +287,15 @@ export default class RScriptEnv extends ContainerObject {
             case RScriptUIElementID.REDO:
                 return this.ui.toolbar.getScriptUIElement(this.ui.toolbar.redoButton);
             case RScriptUIElementID.BOOSTERS:
-                return this.ui.toolbar.getScriptUIElement(this.ui.toolbar.boostersMenuButton);
+                if (this.ui.toolbar.boostersMenuButton.isLiveObject) {
+                    return this.ui.toolbar.getScriptUIElement(this.ui.toolbar.boostersMenuButton);
+                } else {
+                    this.ui.showNotification(
+                        'This tutorial references the boosters feature, which you do not have unlocked.'
+                        + ' Boosters are available once you unlock the lab.'
+                    );
+                    return null;
+                }
             case RScriptUIElementID.SWAP:
                 return this.ui.toolbar.getScriptUIElement(this.ui.toolbar.pairSwapButton);
             case RScriptUIElementID.PIP:


### PR DESCRIPTION
## Summary
Currently, if a tutorial highlights the booster button or waits for it to be clicked, a user
who does not have boosters unlocked will be left with nothing highlighted or stuck. This lets
them know that this is a feature they need to unlock.

## Implementation Notes
While there is some argument to be had about whether it is better to notify the user immediately
on starting the puzzle, inserting the notification when the UI element is actually requested
is by far the most straightforward to implement, so I have done that at least for now. 

## Testing
Tried a tutorial with booster commands while logged out
