### PR TITLE
Fix crash when immediately loading an existing solution

### DIFF
--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -326,7 +326,7 @@ export default class EternaApp extends FlashbangApp {
         return this.loadSolution(puzzleID, solutionID)
             .then(([puzzle, solution, solutions]) => {
                 if (loadInPoseEdit) {
-                    this._modeStack.unwindToMode(new PoseEditMode(puzzle, {initSolution: solution}));
+                    this._modeStack.unwindToMode(new PoseEditMode(puzzle, {initSolution: solution, solutions}));
                 } else {
                     this._modeStack.unwindToMode(new FeedbackViewMode(solution, puzzle, solutions));
                 }


### PR DESCRIPTION
When immediately loading a solution in copy and view mode (not via the design browser), the app would crash as it required the solution list, which was not previously passed
