### PR TITLE
Draw UI lock over all existing dialogs

### DIFF
--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -168,7 +168,7 @@ export default abstract class GameMode extends AppMode {
         let lockDialog = this._uiLockRef.object as UILockDialog;
         if (lockDialog == null) {
             lockDialog = new UILockDialog();
-            this._uiLockRef = this.addObject(lockDialog, this.dialogLayer, 0);
+            this._uiLockRef = this.addObject(lockDialog, this.dialogLayer);
         }
 
         lockDialog.addRef(name);


### PR DESCRIPTION
## Summary
Currently, when a "UI lock" is created (which dims the screen and prevents mouse/keyboard input below it),
it is positioned under all dialogs. This means that any existing dialogs can still be interacted with.
This updates the behavior to instead place the lock at the top of the dialog layer, such that existing
dialogs will be under the lock, but new dialogs will be over the lock.

## Implementation Notes
The git blame indicates this behavior was introduced with screenshot posting. Testing screenshots with
this change, it seemed to behave fine. Either our dialog handling has somehow changed since then,
or it was changed proactively with the assumption that dialogs were always "exceptional" (eg, notifications,
confirmation dialogs, etc) - however now we use dialogs more extensively with the new windowing system
that was introduced with the new toolbar.  
