### PR TITLE
Ensure all actions that require folding to complete actually wait

### DIFF
--- a/src/eterna/mode/PoseEdit/Booster.ts
+++ b/src/eterna/mode/PoseEdit/Booster.ts
@@ -169,10 +169,7 @@ export default class Booster {
             } else {
                 const prevForceSync = this._view.forceSync;
                 this._view.forceSync = true;
-                for (let ii = 0; ii < this._view.numPoseFields; ii++) {
-                    pose = this._view.getPose(ii);
-                    pose.pasteSequence(seqArr);
-                }
+                this._view.pasteSequence(seqArr);
                 this._view.forceSync = prevForceSync;
             }
             return true;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -3813,7 +3813,7 @@ export default class PoseEditMode extends GameMode {
 
         const LOCK_NAME = 'ExecFold';
 
-        const execfoldCB = async (fd: FoldData[] | null) => {
+        const execfoldCB = (fd: FoldData[] | null) => {
             this.hideAsyncText();
             this.popUILock(LOCK_NAME);
 
@@ -3835,7 +3835,7 @@ export default class PoseEditMode extends GameMode {
                 return;
             }
 
-            await this.poseEditByTargetDoFold(targetIndex);
+            return this.poseEditByTargetDoFold(targetIndex);
         };
 
         this.pushUILock(LOCK_NAME);
@@ -3854,17 +3854,16 @@ export default class PoseEditMode extends GameMode {
         );
         if (sol != null && this._puzzle.hasTargetType('multistrand')) {
             this.showAsyncText('retrieving...');
-            const fd = await sol.queryFoldData();
-            execfoldCB(fd);
+            return sol.queryFoldData().then((result) => execfoldCB(result));
         } else {
-            awaut execfoldCB(null);
+            return execfoldCB(null);
         }
         */
 
-        await execfoldCB(null);
+        return execfoldCB(null);
     }
 
-    private async poseEditByTargetDoFold(targetIndex: number) {
+    private poseEditByTargetDoFold(targetIndex: number) {
         this.showAsyncText('folding...');
         this.pushUILock(PoseEditMode.FOLDING_LOCK);
 
@@ -3884,6 +3883,7 @@ export default class PoseEditMode extends GameMode {
                 }
             }
             this.poseEditByTargetEpilog(targetIndex);
+            return Promise.resolve();
         } else {
             for (let ii = 0; ii < this._targetPairs.length; ii++) {
                 this._opQueue.push(new PoseOp(ii + 1, () => this.poseEditByTargetFoldTarget(ii, false)));

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -927,7 +927,26 @@ export default class PoseEditMode extends GameMode {
         // NB: forceSync is always false when we do our initial load
         this._opQueue.push(new PoseOp(
             this._targetPairs.length,
-            () => this.setPuzzleEpilog(initialSequence, this._params.isReset)
+            () => {
+                if (!this._params.isReset) {
+                    this._startSolvingTime = new Date().getTime();
+                }
+
+                if (this._params.isReset) {
+                    this.startPlaying();
+                } else if (initialSequence == null) {
+                    this.startCountdown();
+                } else if (this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL) {
+                    // / Given init sequence (solution) in the lab, don't show mission animation - go straight to game
+                    this.startPlaying();
+                } else {
+                    this.startCountdown();
+                }
+
+                this.setPip(Eterna.settings.pipEnabled.value);
+
+                this.ropPresets();
+            }
         ));
 
         if (fdPromise) {
@@ -3319,27 +3338,6 @@ export default class PoseEditMode extends GameMode {
             }
         }
         return true;
-    }
-
-    private setPuzzleEpilog(initSeq: Sequence | null, isReset: boolean | undefined): void {
-        if (!isReset) {
-            this._startSolvingTime = new Date().getTime();
-        }
-
-        if (isReset) {
-            this.startPlaying();
-        } else if (initSeq == null) {
-            this.startCountdown();
-        } else if (this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL) {
-            // / Given init sequence (solution) in the lab, don't show mission animation - go straight to game
-            this.startPlaying();
-        } else {
-            this.startCountdown();
-        }
-
-        this.setPip(Eterna.settings.pipEnabled.value);
-
-        this.ropPresets();
     }
 
     private checkConstraints(soft: boolean = false): boolean {

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -920,19 +920,16 @@ export default class PoseEditMode extends GameMode {
             this.loadSavedData();
         }
 
-        this._poseEditByTargetCb = () => {
-            if (this.forceSync) {
-                this.setPuzzleEpilog(initialSequence, this._params.isReset);
-            } else {
-                this._opQueue.push(new PoseOp(
-                    this._targetPairs.length,
-                    () => this.setPuzzleEpilog(initialSequence, this._params.isReset)
-                ));
-            }
-            this._poseEditByTargetCb = null;
-        };
-
         this.poseEditByTarget(0);
+
+        if (this.forceSync) {
+            this.setPuzzleEpilog(initialSequence, this._params.isReset);
+        } else {
+            this._opQueue.push(new PoseOp(
+                this._targetPairs.length,
+                () => this.setPuzzleEpilog(initialSequence, this._params.isReset)
+            ));
+        }
 
         if (fdPromise) {
             // We defer reacting to the promise until now so that the PoseOps to set the target structure
@@ -3849,9 +3846,6 @@ export default class PoseEditMode extends GameMode {
                 this.updateScore();
                 this.transformPosesMarkers();
 
-                if (this._poseEditByTargetCb != null) {
-                    this._poseEditByTargetCb();
-                }
                 return;
             }
 
@@ -3928,10 +3922,6 @@ export default class PoseEditMode extends GameMode {
             return new Promise<void>((resolve) => {
                 this._opQueue.push(new PoseOp(null, resolve));
             });
-        }
-
-        if (this._poseEditByTargetCb != null) {
-            this._poseEditByTargetCb();
         }
     }
 
@@ -4363,7 +4353,6 @@ export default class PoseEditMode extends GameMode {
 
     // / Asynch folding
     private _opQueue: PoseOp[] = [];
-    private _poseEditByTargetCb: (() => void) | null = null;
     private _asynchText: Text;
     // / Undo stack
     private _stackLevel: number;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -3813,7 +3813,7 @@ export default class PoseEditMode extends GameMode {
 
         const LOCK_NAME = 'ExecFold';
 
-        const execfoldCB = (fd: FoldData[] | null) => {
+        const execfoldCB = async (fd: FoldData[] | null) => {
             this.hideAsyncText();
             this.popUILock(LOCK_NAME);
 
@@ -3835,7 +3835,7 @@ export default class PoseEditMode extends GameMode {
                 return;
             }
 
-            return this.poseEditByTargetDoFold(targetIndex);
+            await this.poseEditByTargetDoFold(targetIndex);
         };
 
         this.pushUILock(LOCK_NAME);
@@ -3854,13 +3854,14 @@ export default class PoseEditMode extends GameMode {
         );
         if (sol != null && this._puzzle.hasTargetType('multistrand')) {
             this.showAsyncText('retrieving...');
-            return sol.queryFoldData().then((result) => execfoldCB(result));
+            const fd = await sol.queryFoldData();
+            execfoldCB(fd);
         } else {
-            return execfoldCB(null);
+            awaut execfoldCB(null);
         }
         */
 
-        return execfoldCB(null);
+        await execfoldCB(null);
     }
 
     private async poseEditByTargetDoFold(targetIndex: number) {

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -3329,7 +3329,6 @@ export default class PoseEditMode extends GameMode {
                 this._annotationManager.setSolutionAnnotations(annotations.solution);
             }
         }
-        this.poseEditByTarget(0);
         return true;
     }
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -488,10 +488,12 @@ export default class PoseEditMode extends GameMode {
             this.updateScore();
             this.transformPosesMarkers();
         } else {
+            // Note that we do this first
             for (const pose of this._poses) {
                 pose.librarySelections = solution.libraryNT;
+                pose.sequence = solution.sequence;
             }
-            await this.pasteSequence(solution.sequence);
+            await this.poseEditByTarget(0);
             this.setSolutionTargetStructure(foldData);
         }
         this.setAncestorId(solution.nodeID);

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -944,7 +944,6 @@ export default class PoseEditMode extends GameMode {
 
         // Setup RScript and execute the ROPPRE ops
         this._rscript = new RNAScript(this._puzzle, this);
-        this._rscript.tick();
 
         // RScript can set our initial poseState
         this._poseState = this._puzzle.defaultMode;

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1720,13 +1720,12 @@ export default class PoseEditMode extends GameMode {
         this._scriptInterface.addCallback(
             'set_target_structure_async',
             lockDuringFold(
-                (index: number, structure: string, startAt: number = 0): Promise<void> => new Promise((resolve) => {
+                async (index: number, structure: string, startAt: number = 0): Promise<void> => {
                     const pseudoknots = this._targetConditions && this._targetConditions[0]
                         && this._targetConditions[0]['type'] === 'pseudoknot';
 
-                    this.pasteTargetStructure(index, SecStruct.fromParens(structure, pseudoknots), startAt);
-                    this._opQueue.push(new PoseOp(null, () => resolve()));
-                })
+                    await this.pasteTargetStructure(index, SecStruct.fromParens(structure, pseudoknots), startAt);
+                }
             )
         );
 
@@ -2078,7 +2077,7 @@ export default class PoseEditMode extends GameMode {
         }));
     }
 
-    protected pasteTargetStructure(targetIndex: number, structure: SecStruct, startAt: number, poseIdx?: number) {
+    protected async pasteTargetStructure(targetIndex: number, structure: SecStruct, startAt: number, poseIdx?: number) {
         const structureConstraints = this._targetConditions[targetIndex]?.['structure_constraints'];
         if (structureConstraints === undefined) return;
 
@@ -2110,7 +2109,7 @@ export default class PoseEditMode extends GameMode {
         }
         this._targetPairs[targetIndex] = pairs;
 
-        this.poseEditByTarget((poseIdx && this._isPipMode) ? poseIdx : 0);
+        await this.poseEditByTarget((poseIdx && this._isPipMode) ? poseIdx : 0);
     }
 
     private openDesignBrowserForOurPuzzle(): void {
@@ -2421,11 +2420,11 @@ export default class PoseEditMode extends GameMode {
         this._toolbar.redoButton.enabled = !this._isFrozen && !(this._stackLevel + 1 > this._stackSize - 1);
         this._toolbar.freezeButton.toggled.value = this._isFrozen;
 
+        this._background.freezeBackground(this._isFrozen);
+
         if (!this._isFrozen) { // we just "thawed", update
             this.poseEditByTarget(this._curTargetIndex);
         }
-
-        this._background.freezeBackground(this._isFrozen);
     }
 
     // / This mode is strictly for internal use, not to be used by users

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -922,14 +922,11 @@ export default class PoseEditMode extends GameMode {
 
         this.poseEditByTarget(0);
 
-        if (this.forceSync) {
-            this.setPuzzleEpilog(initialSequence, this._params.isReset);
-        } else {
-            this._opQueue.push(new PoseOp(
-                this._targetPairs.length,
-                () => this.setPuzzleEpilog(initialSequence, this._params.isReset)
-            ));
-        }
+        // NB: forceSync is always false when we do our initial load
+        this._opQueue.push(new PoseOp(
+            this._targetPairs.length,
+            () => this.setPuzzleEpilog(initialSequence, this._params.isReset)
+        ));
 
         if (fdPromise) {
             // We defer reacting to the promise until now so that the PoseOps to set the target structure

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -409,10 +409,6 @@ export default class PoseEditMode extends GameMode {
         }
     }
 
-    public publicStartCountdown(): void {
-        this.startCountdown();
-    }
-
     private onHelpClicked() {
         const getBounds = (elem: ContainerObject) => {
             const globalPos = elem.container.toGlobal(new Point());

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -906,6 +906,12 @@ export default class PoseEditMode extends GameMode {
         // reset lineage for experimental targets
         this.setAncestorId(0);
 
+        // Setup RScript and execute the ROPPRE ops
+        this._rscript = new RNAScript(this._puzzle, this);
+
+        // RScript can set our initial poseState
+        this._poseState = this._puzzle.defaultMode;
+
         // We don't load saved data if we're viewing someone else's solution
         // If there's an initial solution, still autoload if we've previously played
         if (
@@ -937,12 +943,6 @@ export default class PoseEditMode extends GameMode {
                 this.popUILock(LOCK_NAME);
             });
         }
-
-        // Setup RScript and execute the ROPPRE ops
-        this._rscript = new RNAScript(this._puzzle, this);
-
-        // RScript can set our initial poseState
-        this._poseState = this._puzzle.defaultMode;
 
         // add 3DWindow
         const threePath = this._puzzle.threePath;

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -355,9 +355,6 @@ export default class PuzzleEditMode extends GameMode {
 
             this.clearUndoStack();
             await this.poseEditByTarget(0);
-            for (const pose of this._poses) {
-                pose.updateHighlightsAndScores();
-            }
         });
 
         this.regs?.add(this._naturalButton.clicked.connect(() => this.setToNativeMode()));

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -1142,7 +1142,7 @@ export default class PuzzleEditMode extends GameMode {
         this._asynchText.visible = false;
     }
 
-    private async poseEditByTarget(index: number): Promise<void> {
+    protected async poseEditByTarget(index: number): Promise<void> {
         this.showAsyncText('folding...');
         this.pushUILock();
         let noChange = true;

--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -1790,12 +1790,6 @@ export default class Pose2D extends ContainerObject implements Updatable {
         this.generateScoreNodes();
     }
 
-    public updateHighlightsAndScores(): void {
-        this._prevOffsetX = -1;
-        this._prevOffsetY = -1;
-        this.generateScoreNodes();
-    }
-
     public set showEnergyHighlight(display: boolean) {
         this._highlightEnergyText = display;
         this.generateScoreNodes();

--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -469,38 +469,6 @@ export default class Pose2D extends ContainerObject implements Updatable {
         }
     }
 
-    public pasteSequence(sequence: Sequence): void {
-        if (sequence == null) {
-            return;
-        }
-
-        const n: number = Math.min(sequence.length, this._sequence.length);
-        let needUpdate = false;
-        const offset: number = (
-            this._oligo != null && this._oligoMode === OligoMode.EXT5P
-        ) ? this._oligo.length : 0;
-
-        // Without this, there is some weird behavior where pasting a sequence across multiple
-        // poses fails to update sequences on all poses. There may be a better fix for that.
-        this._sequence = this._sequence.slice(0);
-
-        for (let ii = 0; ii < n; ii++) {
-            if (sequence.nt(ii) === RNABase.UNDEFINED) continue;
-            if (this._sequence.nt(ii) !== sequence.nt(ii) && !this.isLocked(offset + ii)) {
-                this._sequence.setNt(ii, sequence.nt(ii));
-                this._bases[offset + ii].setType(sequence.nt(ii));
-                needUpdate = true;
-            }
-        }
-
-        if (needUpdate) {
-            this.checkPairs();
-            this.updateMolecule();
-            this.generateScoreNodes();
-            this.callPoseEditCallback();
-        }
-    }
-
     public getBaseLoc(seq: number, out: Point | null = null): Point {
         if (out == null) {
             out = new Point();
@@ -1411,7 +1379,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         this._redraw = true;
     }
 
-    public get puzzleLocks(): boolean[] | undefined {
+    public get puzzleLocks(): boolean[] {
         if (this._locks === undefined) {
             this._locks = Pose2D.createDefaultLocks(this._sequence.length);
         }


### PR DESCRIPTION
## Summary
Improves code clarity and robustness to race conditions related to asynchronous folding

## Implementation Notes
Unless we are in synchronous script mode, whenever a folding operation (or really, anything that requires state to be resynced/an undo state to be created) is triggered, the update is actually queued and run on the next game tick/update cycle - and could in fact be an asynchronous operation which does not complete for some time, even though the game continues to run (though under a UI lock). I've gone through and audited instances where we appear to perform actions immediately after we trigger a fold without waiting for the fold to complete.

I've now verified that we now only trigger async behaviors in callbacks, and if not explicitly awaited, is the very last thing to happen in the callback. The only instance that I did not address is folding engine changes, which is triggered by a FolderSwitcher method which updates its current state and then notifies the mode of a change via a signal. Ideally we would be able to await a manual engine change and the folder switcher would be UI only, but this requires some more time than I have right now and the behavior is fine.

Breaking down the specific changes:
* `poseEditByTarget` now registers a poseOp it can use to return a Promise that callers can `await` on instead of having to do that themselves
* Instead of `pasteSequence` being handled in pose2D (with the update being propagated by the `poseEditCallback` like happens with UI mutations), we now handle this directly in the modes themselves, directly calling `poseEditByTarget` and marking `pasteSequence` async. This also nicely avoids some indirection. Also, note that previously we've called `pasteSequence` in a loop over every pose - this is wholly unnecessary as `poseEditByTarget` already takes care of syncing the updates from the pose that was changed (indicated by `targetIndex`) to other poses.
* `publicStartCountdown` is never used, so removed
* `setSolutionTargetStructure` now assumes callers properly wait for folding to complete before calling it
* `showSolution` is now written more cleanly as an async function, waits for folding to complete before making further undoBlock modifications, and doesnt go through the extra pasteSequence logic (this clarifies where the poseEditByTarget happens since we perform multiple state updates, and there's no need to do the extra validation logic since this is an already submitted sequence)
* We start loading the 3D file if present before folding completes, but wait until it completes to load the 3D window (it does rely on fold completion, but we'd never seen a situation before where we would get this file back before the fold completed)
* RScript does can be initialized before folding completes (it's already designed this way), so we move that before our initial fold
* 3D and initial target loading are moved into a PoseOp so that it happens after the initial fold but before user interaction
* `setPuzzleEpilog`/`_poseEditByTargetCb` was inlined instead of being a magic state variable
* `showNextSolution` now has the `showSolution` call (which actually triggers the state update) at the very end (whether or not eg the solution sidebar shows up before or after doesnt really matter, but it is now consistent)
* `updateHighlightsAndScores` didn't appear to actually be doing anything. It appears that the bug that caused it to be introduced was separately resolved by the highlight being cleared elsewhere eg the update loop (in the same commit)
* Pose2D.puzzleLocks never returns undefined, so it no longer says it can