### PR TITLE
Expand variety of error types that can be displayed

### DIFF
--- a/src/flashbang/util/ErrorUtil.ts
+++ b/src/flashbang/util/ErrorUtil.ts
@@ -11,7 +11,7 @@ export default class ErrorUtil {
     }
 
     /** Returns a reasonable string value for an error object, if possible */
-    public static getErrString(e: Error | ErrorEvent | null, includeStack = true): string {
+    public static getErrString(e: Error | ErrorEvent | string | null | unknown, includeStack = true): string {
         try {
             if (e == null) {
                 return 'Unknown error';
@@ -19,8 +19,16 @@ export default class ErrorUtil {
                 return includeStack && e.stack ? e.stack : e.message;
             } else if (e instanceof ErrorEvent) {
                 return e.error != null ? this.getErrString(e.error, includeStack) : e.message;
+            } else if (typeof e === 'string') {
+                return e;
+            } else if (typeof e === 'object') {
+                return `Unknown error type: object/${e.constructor.name}`;
+            } else if (typeof e === 'function') {
+                return `Unknown error type: function/${e.name}`;
+            } else if (typeof e === 'function') {
+                return `Unknown error type: function/${e.name}`;
             } else {
-                return ''; // unreachable, but necessary for return typechecker
+                return `Unknown error type: ${typeof e}`;
             }
         } catch (errStringError) {
             return 'Unknown error';


### PR DESCRIPTION
Minimally, in some cases we may catch a string as an error - we can easily display that. Also, in case we happen upon some other types, at least give some indication of what the error that was thrown was
