### PR TITLE
Ensure error dialog is displayed if error is encountered in update loop

### DIFF
--- a/src/eterna/Eterna.ts
+++ b/src/eterna/Eterna.ts
@@ -51,10 +51,18 @@ export default class Eterna {
 
     public static onFatalError(err: Error | ErrorEvent): void {
         log.error('Fatal error error', ErrorUtil.getErrorObj(err) || ErrorUtil.getErrString(err));
-        if (Flashbang.app != null
+        if (
+            Flashbang.app != null
             && Flashbang.app.modeStack != null
-            && !(Flashbang.app.modeStack.topMode instanceof ErrorDialogMode)) {
+            && !(Flashbang.app.modeStack.topMode instanceof ErrorDialogMode)
+        ) {
             Flashbang.app.modeStack.pushMode(new ErrorDialogMode(err));
+            // If the error occurred in our update loop, the error will have meant Pixi's update
+            // routine stopped before it could queue up the next frame. We need to keep the update
+            // loop running in order to show our error dialog (...and let things keep running
+            // if they can)
+            Flashbang.app.pixi?.ticker.stop();
+            Flashbang.app.pixi?.ticker.start();
         } else if (process.env.NODE_ENV !== 'production') {
             try {
                 // eslint-disable-next-line no-alert


### PR DESCRIPTION
## Summary
Previously, in some cases (eg, during puzzle load or during fold processing) unhandled errors would cause the app to freeze without displaying the error (or allowing the possibility to try continuing).

## Implementation Notes
The issue was that if the error was thrown as part of the update loop, which is initially triggered by the Pixi ticker's update, and so since the ticker update function is interrupted, the next frame is never queued (and so we never do the mode transition, animate in the dialog, or otherwise keep updating).