### PR TITLE
Throw error if script constraint errors

### DIFF
--- a/src/eterna/constraints/constraints/ScriptConstraint.ts
+++ b/src/eterna/constraints/constraints/ScriptConstraint.ts
@@ -22,6 +22,9 @@ export default class ScriptConstraint extends Constraint<ScriptConstraintStatus>
 
     public evaluate(_context: ConstraintContext): ScriptConstraintStatus {
         const result = ExternalInterface.runScriptSync(this.scriptID, {});
+        if (result.result === false) {
+            throw new Error(result.cause);
+        }
 
         return {
             goal: result.cause.goal != null ? result.cause.goal : '',

--- a/src/eterna/util/ExternalInterface.ts
+++ b/src/eterna/util/ExternalInterface.ts
@@ -229,7 +229,8 @@ export default class ExternalInterface {
 
     /**
      * Runs a named script. Calls a callback with the result of the script, or a different one if
-     * the script has an error.
+     * the script execution process has an error (errors in the script itself will cause a resolution
+     * with the `result` property of the resolved object set to false and `cause` set to the error).
      *
      * This function uses callbacks instead of a Promise because Promise callbacks never run syncronously
      *


### PR DESCRIPTION
## Summary
Currently if an error is encountered while evaluating a script-based constraint, it will resolve but display empty or outdated information. Now, we explicitly throw an error 1) to ensure whatever action that relied on the constraint is interrupted and 2) to allow for easier debugging and error reporting, as the error will be surfaced to the user (as this is a core part of puzzle solving, it seems appropriate to not "gracefully" handle the error since the current behavior could cause confusion and makes it less likely to be reported and harder to track down)

## Implementation Details
Arguably the root "cause" of this is that ExternalInterface resolves whether the script itself succeeded or errored (only rejecting if the script execution process ran into an error), but at this point I'm going to believe wrapping the script result is a reasonable design decision, and downstream consumers can handle it however they need to (while maintaining access to any additional execution metadata provided by the script runtime) 