### PR TITLE
Don't lock script methods during folding if called from script constraints

### DIFF
--- a/src/eterna/constraints/Constraint.ts
+++ b/src/eterna/constraints/Constraint.ts
@@ -1,6 +1,7 @@
 import UndoBlock, {TargetConditions} from 'eterna/UndoBlock';
 import {HighlightType} from 'eterna/pose2D/HighlightBox';
 import Puzzle from 'eterna/puzzle/Puzzle';
+import {ExternalInterfaceCtx} from 'eterna/util/ExternalInterface';
 import {ConstraintBoxConfig} from './ConstraintBox';
 
 export interface BaseConstraintStatus {
@@ -19,6 +20,7 @@ export interface ConstraintContext {
     undoBlocks: UndoBlock[];
     targetConditions?: (TargetConditions | undefined)[];
     puzzle?: Puzzle;
+    scriptConstraintCtx?: ExternalInterfaceCtx;
 }
 
 export default abstract class Constraint<ConstraintStatus extends BaseConstraintStatus> {

--- a/src/eterna/constraints/constraints/ScriptConstraint.ts
+++ b/src/eterna/constraints/constraints/ScriptConstraint.ts
@@ -20,8 +20,10 @@ export default class ScriptConstraint extends Constraint<ScriptConstraintStatus>
         this.scriptID = scriptID;
     }
 
-    public evaluate(_context: ConstraintContext): ScriptConstraintStatus {
-        const result = ExternalInterface.runScriptSync(this.scriptID, {});
+    public evaluate(context: ConstraintContext): ScriptConstraintStatus {
+        const result = ExternalInterface.runScriptSync(this.scriptID, {
+            ctx: context.scriptConstraintCtx
+        });
         if (result.result === false) {
             throw new Error(result.cause);
         }


### PR DESCRIPTION
Script constraints may call various methods that we've started to lock during folding - most obviously, constraints probably need to access the current solution to know whether it passes the constraint or not. Unfortunately, we can't really limit this to a set of reasonable methods (eg, just getters) because there are a bunch of constraints that currently hack in additional functionality this way.

It is still possible that there are some edge cases (eg, a constraint that does some very fast async work which yields the special external interface context and then goes and uses one of these methods before the regular lock releases), but I'm going to leave it like this to attempt being at least a bit safer and hope it doesn't cause issues (and if it does, it's likely it would wind up having other issues _anyways_).