### PR TITLE
Fix set_sequence_string being overridden with a version without async handling

### DIFF
--- a/src/eterna/mode/PoseEdit/Booster.ts
+++ b/src/eterna/mode/PoseEdit/Booster.ts
@@ -157,23 +157,23 @@ export default class Booster {
     private executeScript(pose: Pose2D | null, cmd: string | null, baseNum: number): void {
         const scriptInterface = new ExternalInterfaceCtx();
 
-        scriptInterface.addCallback('set_sequence_string', (seq: string): boolean => {
-            const seqArr: Sequence = Sequence.fromSequenceString(seq);
-            if (seqArr.findUndefined() >= 0 || seqArr.findCut() >= 0) {
-                log.info(`Invalid characters in ${seq}`);
-                return false;
-            }
+        if (this._type === BoosterType.PAINTER && pose) {
+            // Note we don't have to do any async handling here because we are running
+            // in the middle of the paint process. We are not triggering folding and
+            // do not expect folding to complete before we return - that happens
+            // only after painting is completed.
+            scriptInterface.addCallback('set_sequence_string', (seq: string): boolean => {
+                const seqArr: Sequence = Sequence.fromSequenceString(seq);
+                if (seqArr.findUndefined() >= 0 || seqArr.findCut() >= 0) {
+                    log.info(`Invalid characters in ${seq}`);
+                    return false;
+                }
 
-            if (this._type === BoosterType.PAINTER && pose) {
                 pose.setMutated(seqArr);
-            } else {
-                const prevForceSync = this._view.forceSync;
-                this._view.forceSync = true;
-                this._view.pasteSequence(seqArr);
-                this._view.forceSync = prevForceSync;
-            }
-            return true;
-        });
+
+                return true;
+            });
+        }
 
         scriptInterface.addCallback('set_script_status', (): void => {});
 


### PR DESCRIPTION
When executing a booster, we provide it with a context which overrides the set_sequence_string method so that "paint tool" scripts can act directly on the pose during the paint process (eg, allowing a temporary mutation during a mouse move, and avoiding conflicts between the "UI-based" mutation process which was initiated and "script-based" mutation, both of could otherwise trigger fold/undo operations).

However, this method is always overridden and did not change when we changed the base implementation to accommodate async folding (which means the additional checks would not be present when this method is called from a synchronous script). This instead only overrides the method for paint tool scripts, allowing the base implementation to be directly used in all other cases