### PR TITLE
Fix UI locks not applying to info sidebar

### DIFF
--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -106,7 +106,7 @@ export default abstract class GameMode extends AppMode {
 
     /** Show a dialog. Removes any existing modal dialogs if modal. */
     public showDialog<T extends SceneObject>(dialog: T): T;
-    public showDialog<T extends SceneObject>(dialog: T, id: string): T | null;
+    public showDialog<T extends SceneObject>(dialog: T, id: string | undefined): T | null;
     public showDialog<T extends SceneObject>(dialog: T, id?: string): T | null {
         const isModal = !(dialog instanceof WindowDialog) || dialog.modal;
 

--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -63,7 +63,7 @@ export default abstract class GameMode extends AppMode {
         this.container.addChild(this.dialogLayer);
         this.dialogLayer.name = 'dialogLayer';
         this.container.addChild(this.sidebarLayer);
-        this.dialogLayer.name = 'sidebarLayer';
+        this.sidebarLayer.name = 'sidebarLayer';
         this.container.addChild(this.notifLayer);
         this.notifLayer.name = 'notifLayer';
         this.container.addChild(this.achievementsLayer);

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -280,8 +280,8 @@ export default class PoseEditMode extends GameMode {
         this._asynchText.visible = false;
     }
 
-    public override pushUILock(name?: string, sidebarOnly?: boolean) {
-        if (!sidebarOnly) super.pushUILock(name);
+    public override pushUILock(name?: string) {
+        super.pushUILock(name);
 
         let sidebarLockDialog = this._sidebarLockRef.object as UILockDialog;
         if (sidebarLockDialog == null) {
@@ -293,8 +293,8 @@ export default class PoseEditMode extends GameMode {
         sidebarLockDialog.addRef(name);
     }
 
-    public override popUILock(name?: string, sidebarOnly?: boolean) {
-        if (!sidebarOnly) super.popUILock(name);
+    public override popUILock(name?: string) {
+        super.popUILock(name);
 
         if (this._sidebarLockRef.isLive) {
             (this._sidebarLockRef.object as UILockDialog).releaseRef(name);
@@ -313,9 +313,12 @@ export default class PoseEditMode extends GameMode {
         const isModal = !(dialog instanceof WindowDialog) || dialog.modal;
 
         if (isModal) {
-            const LOCK_NAME = 'MODAL_LOCK';
-            this.pushUILock(LOCK_NAME, true);
-            dialogRef?.closed.then(() => this.popUILock(LOCK_NAME, true));
+            if (this._solutionView?.container.visible) {
+                this._solutionView.container.visible = false;
+                dialogRef?.closed.then(() => {
+                    if (this._solutionView) this._solutionView.container.visible = true;
+                });
+            }
         }
 
         return dialogRef;


### PR DESCRIPTION
## Summary
Currently, when the UI is locked, the sidebar can still be interacted with. This is now prevented.

## Implementation Notes
* This would be trivially solved if the sidebar could be under dialogs (where it realistically belongs). However, due to it containing HTML content that would render over other dialogs, we do not allow this. Therefore I instead draw a second lock dialog on top of the sidebar layer and mask it to where the sidebar is.
* I also handle "modal dialogs", which should have the same effect of locking the UI. However in this case, I also hide the sidebar entirely since otherwise you may not be able to see/interact with part of the likely statically-positioned dialog if the screen is small enough.
* The use of `any` here is due to typescript generic inference limitations. This is type safe from the consumer level, it just leaves us open to misusing the return of the dialog closure, which we should never touch anyways.
* While I was debugging I also noticed dialogLayer and sidebayLayer had the wrong container names (surfaced in the pixi devtools). This is now resolved.