### PR TITLE
Fix improper disambiguation with multiple dynamic paint tools

### DIFF
--- a/src/eterna/mode/PoseEdit/Booster.ts
+++ b/src/eterna/mode/PoseEdit/Booster.ts
@@ -17,7 +17,7 @@ export enum BoosterType {
 export interface BoosterData {
     type?: string;
     icons_b64?: string[];
-    label: string;
+    label?: string;
     tooltip: string;
     script: string;
 }
@@ -71,7 +71,7 @@ export default class Booster {
         view: GameMode,
         type: BoosterType,
         toolColor: number,
-        label: string,
+        label: string | undefined,
         tooltip: string,
         scriptNID: string,
         buttonStateTextures: Texture[]
@@ -209,7 +209,7 @@ export default class Booster {
     private readonly _view: GameMode;
     private readonly _toolColor: number;
     private readonly _type: BoosterType;
-    private readonly _label: string;
+    private readonly _label: string | undefined;
     private readonly _tooltip: string;
     private readonly _scriptID: string;
     private readonly _buttonStateTextures: (Texture | null)[] = [null, null, null, null, null];

--- a/src/eterna/ui/toolbar/Toolbar.ts
+++ b/src/eterna/ui/toolbar/Toolbar.ts
@@ -605,7 +605,7 @@ export default class Toolbar extends ContainerObject {
     private setupDynamicPaintTools() {
         if (this._boostersData?.paint_tools) {
             const mode: PoseEditMode = this.mode as PoseEditMode;
-            for (const data of this._boostersData.paint_tools) {
+            for (const [idx, data] of this._boostersData.paint_tools.entries()) {
                 Booster.create(mode, data).then((booster) => {
                     booster.onLoad();
 
@@ -617,8 +617,8 @@ export default class Toolbar extends ContainerObject {
 
                     const boosterPaintButton = this.setupButton({
                         cat: ButtonCategory.SOLVE,
-                        id: booster.label,
-                        displayName: booster.label,
+                        id: `DYNAMIC-${idx}`,
+                        displayName: booster.label ?? '',
                         isPaintTool: true,
                         allImg: booster.buttonStateTextures[0],
                         overImg: booster.buttonStateTextures[1] ? booster.buttonStateTextures[1]
@@ -626,7 +626,6 @@ export default class Toolbar extends ContainerObject {
                         disableImg: booster.buttonStateTextures[4] ? booster.buttonStateTextures[4]
                             : booster.buttonStateTextures[0],
                         tooltip: booster.tooltip,
-                        label: booster.label,
                         fontSize: 14
                     });
                     boosterPaintButton.clicked.connect(() => {


### PR DESCRIPTION
## Summary
This fixes a bug in puzzles like https://eternagame.org/puzzles/8787266/play where we have multiple "dynamic"/script-based paint tools (eg in this case, two MS2 stamper variants) where interacting with the toolbar buttons can select both, hotbar setup can grab the wrong one, etc.

## Implementation Notes
We assumed that these paint tools would always have a unique label. It appears that the label property is not always present, so we instead generate a unique ID.
