### PR TITLE
Fix viewing dot plot of existing solution

### DIFF
--- a/src/eterna/UndoBlock.ts
+++ b/src/eterna/UndoBlock.ts
@@ -653,7 +653,7 @@ export default class UndoBlock {
         }
 
         const currDotPlot = this.getParam(UndoBlockParam.DOTPLOT, EPars.DEFAULT_TEMPERATURE, pseudoknots);
-        if (currDotPlot === undefined) {
+        if (currDotPlot == null) {
             let dotArray: DotPlot | null;
             if (sync) {
                 if (!folder.isSync()) throw new Error('Tried to use asynchronous folder synchronously');


### PR DESCRIPTION
## Summary
This fixes an issue where viewing the dot plot of a previously submitted solution would display a blank area instead of the dot plot

## Implementation Notes
In a0c49d3148f69e9990c79b62139783ba3a5bd29f we started removing dot plot and melt plot data from the fold data uploaded with a solution. Specifically, we set those properties to null. However, when we check if we need to calculate that information, we only checked if it is undefined - meaning that in these cases where it was set to null, we'd treat the dot plot as already present and not (re)compute it. We now trigger the computation if it is either null or undefined (both cases where it is not already available).