### PR TITLE
Fix rnnet not reusing created inference sessions

### DIFF
--- a/src/eterna/folding/RNNet.ts
+++ b/src/eterna/folding/RNNet.ts
@@ -214,8 +214,10 @@ export default class RNNet extends Folder<false> {
         // because it breaks YouTube and Vimeo embeds
         ort.env.wasm.numThreads = 1;
 
-        return ort.InferenceSession.create(rnnetSs.default, {});
+        const session = await ort.InferenceSession.create(rnnetSs.default, {});
+        this._session = session;
+        return session;
     }
 
-    private readonly _session: ort.InferenceSession;
+    private _session: ort.InferenceSession;
 }


### PR DESCRIPTION
## Summary
This fixes an issue where we created a new instance of the RNNet model every time we perform a fold instead of instantiating it once the first time it's run and then reusing it (causing runaway memory usage and adding additional unnecessary computation overhead).

## Implementation Notes
We changed to "memoizing" the inference session so that we could only load rnnet when required instead of always loading it when the app starts. However, I neglected to actually save the value after initializing it, so it was always recreated (plus it appears that due to the implementation of InferenceSession, its resources are not released when it goes out of scope).