### PR TITLE
Incrementally load solutions

### DIFF
--- a/src/eterna/net/GameClient.ts
+++ b/src/eterna/net/GameClient.ts
@@ -129,8 +129,10 @@ export default class GameClient {
             });
     }
 
-    public getSolutions(puzzleID: number): Promise<JSONData> {
-        return this.get(GameClient.GET_URI, {type: 'solutions', puznid: puzzleID})
+    public getSolutions(puzzleID: number, limit: number, skip: number): Promise<JSONData> {
+        return this.get(GameClient.GET_URI, {
+            type: 'solutions', puznid: puzzleID, limit, skip
+        })
             .then((rsp) => rsp.json());
     }
 


### PR DESCRIPTION
## Summary
Currently, we're hitting memory limits in our API due to the amount of data we pull back when loading all solutions at once. This now breaks up loading solutions into multiple requests.
