### PR TITLE
Fix crash when trying to draw base rope with only one nucleotide

### DIFF
--- a/src/eterna/pose2D/BaseRope.ts
+++ b/src/eterna/pose2D/BaseRope.ts
@@ -64,16 +64,19 @@ export default class BaseRope extends GameObject implements LateUpdatable {
             }
         }
 
-        if (Arrays.deepEqual(ropes, this._lastRopes) && this._graphics.geometry.points.length > 0) {
+        // We can only draw a rope when there is more than one point
+        const validRopes = ropes.filter((rope) => rope[0].length > 1);
+
+        if (Arrays.deepEqual(validRopes, this._lastRopes) && this._graphics.geometry.points.length > 0) {
             // base positions haven't changed, and baseRope has not been cleared,
             // so no need to update -- just return.
             return;
         }
 
-        this._lastRopes = ropes;
+        this._lastRopes = validRopes;
 
         this._graphics.clear();
-        for (const rope of ropes) {
+        for (const rope of validRopes) {
             this.drawBaseRope(rope[0], rope[1]);
         }
     }


### PR DESCRIPTION
## Summary
This fixes a crash that would occur if the base rope is enabled for a puzzle where there is a strand only
one nucleotide long (eg, the openvaccine "leaderboard puzzles")

## Implementation Notes
The bug would actually occur internally to pchip, where it would attempt to get the second point, which does not exist

## Testing
Ran "normal" and 1-nt puzzle with base rope enabled and disabled

