### PR TITLE
Dot-bracket parsing reversed capitalization support + better errors

### DIFF
--- a/src/eterna/rnatypes/__tests__/SecStruct.test.ts
+++ b/src/eterna/rnatypes/__tests__/SecStruct.test.ts
@@ -35,6 +35,7 @@ test(`SecStruct:setPairs (pseudoknotted)`, () => {
         '.(((((...{{{{...))))).}}}}....((((....))))',
         '((((((.[[..[[..{{.]]]]{.{...))))).)}}}.}',
         '((((((...{{[[{{...)))]])))}}}}',
+
         'aaaaaa......AAAAAA',
         'aaaaaabbbb......BBBBAAAAAA',
         'aaaaaa...bbbb...AAAAAABBBB',
@@ -42,7 +43,12 @@ test(`SecStruct:setPairs (pseudoknotted)`, () => {
         '.aaaaa...bbbb...AAAAA.BBBB....aaaa....AAAA',
         'aaaaaa.cc..cc..bb.CCCCb.b...AAAAA.ABBB.B',
         'aaaaaa...bbccbb...AAACCAAABBBB',
-        `([{<${alpha}....)]}>${alpha.toUpperCase()}`
+
+        `([{<${alpha}....)]}>${alpha.toUpperCase()}`,
+
+        'BBBB...bbbb',
+        'BBABB...bbabb',
+        '((((({<A[[[....))))).......}>]a]]',
     ];
     const outputStrs = [
       '.........................',
@@ -53,6 +59,7 @@ test(`SecStruct:setPairs (pseudoknotted)`, () => {
       '.(((((...[[[[...))))).]]]]....((((....))))',
       '((((((.((..((..[[.))))[.[...))))).)]]].]',
       '((((((...[[[[{{...)))]])))}}]]',
+      
       '((((((......))))))',
       '((((((((((......))))))))))',
       '((((((...[[[[...))))))]]]]',
@@ -60,16 +67,55 @@ test(`SecStruct:setPairs (pseudoknotted)`, () => {
       '.(((((...[[[[...))))).]]]]....((((....))))',
       '((((((.((..((..[[.))))[.[...))))).)]]].]',
       '((((((...[[[[{{...)))]])))}}]]',
-      '([{<abcdefghijklmnopqrstuvwxyz....)]}>ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+      '([{<abcdefghijklmnopqrstuvwxyz....)]}>ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+
+      '((((...))))',
+      '(((((...)))))',
+      '((((([{<aa<....))))).......]}>>AA',
     ];
 
     for (let i=0; i<inputStrs.length; i++) {
+        console.log(inputStrs[i])
         const ss = new SecStruct();
         ss.setPairs(inputStrs[i], true);
         expect(ss.pairs).toMatchSnapshot(inputStrs[i]);
         const dbn = ss.getParenthesis({ pseudoknots: true });
         expect(dbn).toBe(outputStrs[i]);
         outputStrs.push(dbn);
+    }
+});
+
+test(`SecStruct:setPairs (error cases)`, () => {
+    const inputs = [
+        // Unbalanced
+        ['(((...))))', false],
+        ['(((...))))', true],
+        ['(((', false],
+        ['(((', true],
+        ['...)))', false],
+        ['...)))', true],
+
+        // Unknown characters
+        ['xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', false],
+        ['xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', true],
+        ['-(((((..(((((....)))))((((((((.((...-----((((((..(((((((..)))))))(((((({..[[[[[[[)))))))))))..).))).))))))))))))}.]]]]]]]...', false],
+        ['-(((((..(((((....)))))((((((((.((...-----((((((..(((((((..)))))))(((((({..[[[[[[[)))))))))))..).))).))))))))))))}.]]]]]]]...', true],
+        ['(((....))) (((....)))', false],
+        ['(((....))) (((....)))', true],
+
+        // Mixed orientation
+        ['aB...bA', true],
+
+        // PKs disabled
+        ['[...]', false],
+        ['a...A', false],
+    ] as [string, boolean][];
+    for (const input of inputs) {
+        console.log(input);
+        const ss = new SecStruct();
+        expect(() => {
+            ss.setPairs(...input)
+        }).toThrow();
     }
 });
 

--- a/src/eterna/rnatypes/__tests__/__snapshots__/SecStruct.test.ts.snap
+++ b/src/eterna/rnatypes/__tests__/__snapshots__/SecStruct.test.ts.snap
@@ -204,6 +204,44 @@ exports[`SecStruct:setPairs (pseudoknotted): (((((({{{{......}}}})))))) 1`] = `
 ]
 `;
 
+exports[`SecStruct:setPairs (pseudoknotted): ((((({<A[[[....))))).......}>]a]] 1`] = `
+[
+  19,
+  18,
+  17,
+  16,
+  15,
+  27,
+  28,
+  30,
+  32,
+  31,
+  29,
+  -1,
+  -1,
+  -1,
+  -1,
+  4,
+  3,
+  2,
+  1,
+  0,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  -1,
+  5,
+  6,
+  10,
+  7,
+  9,
+  8,
+]
+`;
+
 exports[`SecStruct:setPairs (pseudoknotted): ([{<abcdefghijklmnopqrstuvwxyz....)]}>ABCDEFGHIJKLMNOPQRSTUVWXYZ 1`] = `
 [
   34,
@@ -394,6 +432,40 @@ exports[`SecStruct:setPairs (pseudoknotted): .aaaaa...bbbb...AAAAA.BBBB....aaaa.
   32,
   31,
   30,
+]
+`;
+
+exports[`SecStruct:setPairs (pseudoknotted): BBABB...bbabb 1`] = `
+[
+  12,
+  11,
+  10,
+  9,
+  8,
+  -1,
+  -1,
+  -1,
+  4,
+  3,
+  2,
+  1,
+  0,
+]
+`;
+
+exports[`SecStruct:setPairs (pseudoknotted): BBBB...bbbb 1`] = `
+[
+  10,
+  9,
+  8,
+  7,
+  -1,
+  -1,
+  -1,
+  3,
+  2,
+  1,
+  0,
 ]
 `;
 


### PR DESCRIPTION
## Summary
* Handle pseudoknotted dot-bracket strings where uppercase letters occur before lowercase letters
* Differentiate unbalanced parenthesis and unknown character errors (and clarify wording)
* Error if pairs are opened but never closed
* Remove assign-in-conditional optimization (realistically this was probably an over-optimization needlessly reducing readability)
* Adjust case order for clarity (and, possibly a small performance gain)
* Add additional comments
* Add test cases for error scenarios

## Testing
Unit tests

## Related Issues
Additional work in service of #789