### PR TITLE
Provide info about script constraint when encountering an error

### DIFF
--- a/src/eterna/constraints/constraints/ScriptConstraint.ts
+++ b/src/eterna/constraints/constraints/ScriptConstraint.ts
@@ -25,7 +25,7 @@ export default class ScriptConstraint extends Constraint<ScriptConstraintStatus>
             ctx: context.scriptConstraintCtx
         });
         if (result.result === false) {
-            throw new Error(result.cause);
+            throw new Error(`SCRIPT constraint ${this.scriptID} failed with error: ${result.cause}`);
         }
 
         return {


### PR DESCRIPTION
If a SCRIPT constraint errors, we currently throw an error with the error details we were provided. However, this can be opaque, especially in Chrome where you can encounter errors like "Cannot read properties of undefined" without the name of the variable. Now, we explicitly note that we've encountered an error in a SCRIPT constraint and which script it was. Since the error could be caused by a misconfiguration by the puzzle author, this also may help the puzzle author identify and troubleshoot the issue.
