### PR TITLE
Rename BPPF1NATIVEPKMIN to BPPF1NATIVEPKMASKMIN

### DIFF
--- a/src/eterna/constraints/constraints/ConfidenceConstraint.ts
+++ b/src/eterna/constraints/constraints/ConfidenceConstraint.ts
@@ -103,7 +103,7 @@ export class NativeConfidenceConstraint extends BaseConfidenceConstraint {
 }
 
 export class NativePKConfidenceConstraint extends BaseConfidenceConstraint {
-    public static readonly NAME = 'BPPF1NATIVEPKMIN';
+    public static readonly NAME = 'BPPF1NATIVEPKMASKMIN';
 
     public evaluate(context: ConstraintContext): ConfidenceConstraintStatus {
         return this._evaluate(context, true);


### PR DESCRIPTION
To prevent potential overlap if we create new constraints with alternate methods for handling PKs
