### PR TITLE
Fix bugs in PK confidence constraint

### DIFF
--- a/src/eterna/constraints/constraints/ConfidenceConstraint.ts
+++ b/src/eterna/constraints/constraints/ConfidenceConstraint.ts
@@ -35,8 +35,8 @@ abstract class BaseConfidenceConstraint extends Constraint<ConfidenceConstraintS
             pairs = pairs.getCrossedPairs();
             dotplot = dotplot.slice();
             for (let i = 0; i < dotplot.length; i += 3) {
-                const a = dotplot[i];
-                const b = dotplot[i + 1];
+                const a = dotplot[i] - 1;
+                const b = dotplot[i + 1] - 1;
                 if (!pairs.isPaired(a) && !pairs.isPaired(b)) {
                     dotplot[i + 2] = 0;
                 }
@@ -45,7 +45,7 @@ abstract class BaseConfidenceConstraint extends Constraint<ConfidenceConstraintS
 
         const square: boolean = (undoBlock.folderName === Vienna.NAME || undoBlock.folderName === Vienna2.NAME);
         const conf = FoldUtil.expectedAccuracy(
-            undoBlock.targetAlignedNaturalPairs,
+            pairs,
             new DotPlot(dotplot),
             square ? BasePairProbabilityTransform.SQUARE : BasePairProbabilityTransform.LEAVE_ALONE
         ).f1;

--- a/src/eterna/rnatypes/SecStruct.ts
+++ b/src/eterna/rnatypes/SecStruct.ts
@@ -520,6 +520,7 @@ export default class SecStruct {
         const newStruct = new SecStruct(new Array(this.length).fill(-1));
         for (const pair of crossedPairs) {
             newStruct.setPairingPartner(pair[0], pair[1]);
+            newStruct.setPairingPartner(pair[1], pair[0]);
         }
         return newStruct;
     }


### PR DESCRIPTION
## Summary
There were a few bugs which caused the confidence constraint calculation for pseudoknots to be incorect:
* The desired pairs were marked as all pairs, not just crossed pairs
* Some pairing probabilities were not considered when they should have been, as checking which pairs were crossed only worked from one side of the pair
* Indices of base pairs which should have been zeroed out were off by one

## Implementation Notes
The issue with getCrossedPairs having some pairs only filled out from one side technically had effects beyond this, but this was the only case where it caused an error (its other use is in RNNet.getEf1CrossPair, which only relies on the "lower half" of the pair being filled out

## Related Issues
Continues #791
