### PR TITLE
Fix crash/update failure with constraints requiring dotplots when loading a cached design

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -3930,7 +3930,7 @@ export default class PoseEditMode extends GameMode {
         // loading, and we don't have a good way of dealing with that, so we're going to avoid just loading the
         // solution cache, at least for now. If you attempt to add this later, don't forget that:
         // 1) we didn't used to record the folding engine used and 2) we wouldn't want to load the target structure
-        // of the solutin that had its fold cached
+        // of the solution that had its fold cached
         // NOTE: If we do re-enable this, we should change it to add an async PoseOp to opQueue so that
         // we ensure we avoid race conditions - namely if we have an initial solution, we need to ensure
         // the folding is done before we execute the operations to set the solution's custom target structure.

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -3924,9 +3924,7 @@ export default class PoseEditMode extends GameMode {
         this.establishTargetPairs(targetIndex);
         this.syncUpdatesFromPose(targetIndex);
 
-        if (this._isFrozen) {
-            return;
-        }
+        if (this._isFrozen) return;
 
         // JAR: We're now uploading data across multiple engines from the submitter for post-hoc analysis and solution
         // loading, and we don't have a good way of dealing with that, so we're going to avoid just loading the
@@ -3950,7 +3948,7 @@ export default class PoseEditMode extends GameMode {
                 if (foldData) return this.loadCachedUndoBlocks(foldData);
             }
         }
-            */
+        */
 
         return this.poseEditByTargetDoFold(targetIndex);
     }


### PR DESCRIPTION
## Summary
Previously, when switching between designs with next/previous, constraints like the confidence constraint which requires the dot plot to be computed would fail to update - and in fact, throw an error and not complete the solution load process - without a cached dot plot in the loaded solution.

## Implementation Notes
There is a new util function loadCachedUndoBlocks. This avoids previous duplication with the (currently disabled) mutation-time fold cache, and moves this code closer to `poseEditByTarget` which is the "alternative" method for doing this kind of work (and maybe eventually we can improve unification between these codepaths). The main goal here is to at least avoid doing the extra "folding operation" in a random part of the code we'd be liable to forget about if we need to tweak dot plot pre-computation later. Bonus, this is also clearer.

Also I took this opportunity to finally clean up the `execfoldCB` thing in `poseEditByTarget` to remove the indirection which confuses me every time I look at it (we had to touch part of that code anyways).

## Testing
Tested next/previous solution and simple mutations on OK round 6 puzzle with this constraint

## Related Issues
Continues #791
