### PR TITLE
Display error with ID of solution if error is encountered when loading solution list

### DIFF
--- a/src/eterna/puzzle/SolutionManager.ts
+++ b/src/eterna/puzzle/SolutionManager.ts
@@ -5,6 +5,7 @@ import Sequence from 'eterna/rnatypes/Sequence';
 import {BundledAnnotationData} from 'eterna/AnnotationManager';
 import {DesignCategory} from 'eterna/mode/DesignBrowser/DesignBrowserMode';
 import SecStruct from 'eterna/rnatypes/SecStruct';
+import {ErrorUtil} from 'flashbang';
 import Solution from './Solution';
 
 interface SolutionSpec {
@@ -97,7 +98,13 @@ export default class SolutionManager {
 
             skip += PAGE_SIZE - PAGE_OVERLAP;
         }
-        this._solutions = Array.from(loaded.values()).map((solution) => SolutionManager.processData(solution));
+        this._solutions = Array.from(loaded.values()).map((solution) => {
+            try {
+                return SolutionManager.processData(solution);
+            } catch (e) {
+                throw new Error(`Failed loading solution ${solution.id}: ${ErrorUtil.getErrString(e, false)}`);
+            }
+        });
         return this._solutions;
     }
 


### PR DESCRIPTION
## Summary
We've recently run into situations where errors are thrown when parsing solutions, eg due to an invalid estimate structure. This currently requires a fair amount of extra work to track down which solution is causing issues. Now, we explicitly include the ID of the solution that encountered an error in the error message.

## Testing
Validated when loading design browser for a puzzle which had a solution with an invalid estimate structure
