### PR TITLE
Dont allow navigating solutions while frozen

### DIFF
--- a/src/eterna/mode/DesignBrowser/ViewSolutionOverlay.ts
+++ b/src/eterna/mode/DesignBrowser/ViewSolutionOverlay.ts
@@ -159,6 +159,11 @@ export default class ViewSolutionOverlay extends ContainerObject {
         return this._parentMode;
     }
 
+    public setSolutionNavigationEnabled(enabled: boolean) {
+        this._prevButton.enabled = enabled;
+        this._nextButton.enabled = enabled;
+    }
+
     private populate() {
         const {theme} = ViewSolutionOverlay;
 
@@ -466,7 +471,7 @@ export default class ViewSolutionOverlay extends ContainerObject {
         this._footer.addChild(footerLinks);
 
         // Previous
-        const previous = new ButtonWithIcon({
+        this._prevButton = new ButtonWithIcon({
             icon: Bitmaps.ImgPrevious,
             text: {
                 text: 'Previous',
@@ -475,12 +480,12 @@ export default class ViewSolutionOverlay extends ContainerObject {
             },
             frame: null
         });
-        this.regs.add(previous.clicked.connect(() => this._props.onPrevious()));
-        previous.hotkey(KeyCode.KeyU);
-        this._content.addObject(previous, footerLinks);
+        this.regs.add(this._prevButton.clicked.connect(() => this._props.onPrevious()));
+        this._prevButton.hotkey(KeyCode.KeyU);
+        this._content.addObject(this._prevButton, footerLinks);
 
         // Next
-        const next = new ButtonWithIcon({
+        this._nextButton = new ButtonWithIcon({
             icon: Bitmaps.ImgNext,
             iconPosition: 'right',
             text: {
@@ -490,10 +495,12 @@ export default class ViewSolutionOverlay extends ContainerObject {
             },
             frame: null
         });
-        this.regs.add(next.clicked.connect(() => this._props.onNext()));
-        next.container.position.x = theme.width - theme.margin.right - theme.margin.left - next.container.width;
-        next.hotkey(KeyCode.KeyD);
-        this._content.addObject(next, footerLinks);
+        this.regs.add(this._nextButton.clicked.connect(() => this._props.onNext()));
+        this._nextButton.container.position.x = (
+            theme.width - theme.margin.right - theme.margin.left - this._nextButton.container.width
+        );
+        this._nextButton.hotkey(KeyCode.KeyD);
+        this._content.addObject(this._nextButton, footerLinks);
 
         this._footer.addVSpacer(20);
 
@@ -685,4 +692,6 @@ export default class ViewSolutionOverlay extends ContainerObject {
     private _voteButton: ButtonWithIcon;
     private _footer: VLayoutContainer;
     private _parentMode: GameMode;
+    private _nextButton: GameButton;
+    private _prevButton: GameButton;
 }

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1961,6 +1961,7 @@ export default class PoseEditMode extends GameMode {
         });
         this._solutionView.container.visible = visible || forceShow;
         this.addObject(this._solutionView, this.sidebarLayer);
+        this._solutionView.setSolutionNavigationEnabled(!this._isFrozen);
 
         this._solutionView.seeResultClicked.connect(() => {
             this.switchToFeedbackViewForSolution(solution);
@@ -2488,6 +2489,7 @@ export default class PoseEditMode extends GameMode {
 
     private toggleFreeze(): void {
         this._isFrozen = !this._isFrozen;
+        if (this._solutionView) this._solutionView.setSolutionNavigationEnabled(!this._isFrozen);
 
         this._constraintsLayer.alpha = (this._isFrozen ? 0.25 : 1.0);
         this.setShowTotalEnergy(!this._isFrozen);


### PR DESCRIPTION
## Summary
Currently, loading solutions while freeze mode is enabled can lead to various problematic behavior:
* Running expensive computations anyways (eg, when loadCachedUndoBlocks needs to trigger a dot plot update)
* Leaving some information out of date while other information is up to date, leading to potential player confusion (eg, if some information is not in the cached undo block and the previous state is used) - and potentially changing which information is out of date or not between designs based on whether/how much data is cached
* Crashes (eg, with no cached undo block and you try to load the native structure)

Now, we instead prevent changing solutions to avoid these cases

## Implementation Notes
There are use cases where it could be valuable to scroll through designs while frozen, even if not all information is available. Ideally in the future, we can display as much information as we have cached (or can trivially calculate) and mark other things as "unavailable". However, that will require more work than we have time for right now, so instead I am doing this to prevent more significant problems from occurring (talking to a couple users, this is not something anyone currently does anyways).

## Testing
Opened a solution, changed solutions, froze, tried changing. Tried with dialog open and closed