### PR TITLE
 Prevent focusing inputs from causing page to scroll offscreen 

### DIFF
--- a/assets/Styles/styles.css
+++ b/assets/Styles/styles.css
@@ -7,7 +7,6 @@ body {
 #maingame {
     width: 100%;
     height: 100%;
-    overflow: hidden;
     background-image: radial-gradient(ellipse, rgb(2, 38, 76) 0%, rgb(3, 27, 60) 70%);
 }
 

--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -2,7 +2,8 @@ import 'assets/Styles/styles.css'; // css-loader will pick up on this and embed 
 import {settings, Application, utils} from 'pixi.js';
 import log from 'loglevel';
 import {
-    FlashbangApp, SaveGameManager, TextureUtil, ErrorUtil, Flashbang, Assert
+    FlashbangApp, SaveGameManager, TextureUtil, ErrorUtil, Flashbang, Assert,
+    ElementSignal
 } from 'flashbang';
 import ChatManager from 'eterna/ChatManager';
 import Eterna from 'eterna/Eterna';
@@ -145,6 +146,13 @@ export default class EternaApp extends FlashbangApp {
             throw new Error(`Could not find HTML element with ID ${params.containerID}`);
         }
         eternaContainer.style.position = 'relative';
+        eternaContainer.style.overflow = 'hidden';
+
+        const scroll = new ElementSignal(eternaContainer, 'scroll');
+        Assert.assertIsDefined(this._regs);
+        this._regs.add(scroll.connect(() => {
+            eternaContainer.scrollLeft = 0;
+        }));
 
         const pixiContainer: HTMLElement = document.createElement('div');
         pixiContainer.id = Eterna.PIXI_CONTAINER_ID;

--- a/src/eterna/ui/ScrollContainer.ts
+++ b/src/eterna/ui/ScrollContainer.ts
@@ -4,42 +4,6 @@ import {
 } from 'flashbang';
 import Eterna from 'eterna/Eterna';
 
-const events = [
-    'pointercancel', 'pointerdown', 'pointerenter', 'pointerleave', 'pointermove',
-    'pointerout', 'pointerover', 'pointerup', 'mousedown', 'mouseenter', 'mouseleave',
-    'mousemove', 'mouseout', 'mouseover', 'mouseup', 'mousedown', 'mouseup', 'click',
-    'wheel'
-] as const;
-
-let earlyHandlers: ((e: MouseEvent | PointerEvent | WheelEvent) => void)[] = [];
-
-// Why are you doing this, you might ask? First off, see ScrollContainer#handlePossiblyMaskedEvent
-// Ok, got that? Lets continue. For some mouse events, Pixi registers listeners on the window with capturing
-// enabled, which means that it gets notified of events dispatched on children before event listeners
-// on the children themselves do. This is the only way for us to make sure we can catch an event
-// and prevent it from propagating before Pixi has a chance to say "well, that event was fired on
-// something that wasn't the Pixi canvas, so that must mean our canvas has lost focus" (and as such,
-// refusing to do things like fire a pointertap because it threw away references to tracked pointers,
-// thinking we started a tap and canceled it by releasing our mouse outside the canvas).
-for (const event of events) {
-    // eslint-disable-next-line no-loop-func
-    window.addEventListener(event, (e) => {
-        earlyHandlers.forEach((handler) => handler(e));
-    }, true);
-}
-
-// Same deal but for touch events
-const touchEvents = ['touchstart', 'touchcancel', 'touchend', 'touchmove'] as const;
-
-let earlyTouchHandlers: ((e: TouchEvent) => void)[] = [];
-
-for (const event of touchEvents) {
-    // eslint-disable-next-line no-loop-func
-    window.addEventListener(event, (e) => {
-        earlyTouchHandlers.forEach((handler) => handler(e));
-    }, true);
-}
-
 export default class ScrollContainer extends ContainerObject {
     public readonly content = new Container();
 
@@ -48,8 +12,6 @@ export default class ScrollContainer extends ContainerObject {
         this._width = width;
         this._height = height;
         this._radius = radius;
-        this._boundHME = this.handlePossiblyMaskedEvent.bind(this);
-        this._boundHTE = this.handleTouchEvent.bind(this);
     }
 
     protected added() {
@@ -70,18 +32,12 @@ export default class ScrollContainer extends ContainerObject {
         overlayEl.appendChild(this._htmlWrapper);
 
         this.doLayout();
-
-        earlyHandlers.push(this._boundHME);
-        earlyTouchHandlers.push(this._boundHTE);
-        Assert.assertIsDefined(Flashbang.app.pixi);
     }
 
     protected dispose(): void {
         const overlayEl = document.getElementById(Eterna.OVERLAY_DIV_ID);
         Assert.assertIsDefined(overlayEl);
         overlayEl.removeChild(this._htmlWrapper);
-        earlyHandlers = earlyHandlers.filter((handler) => handler !== this._boundHME);
-        earlyTouchHandlers = earlyTouchHandlers.filter((handler) => handler !== this._boundHTE);
         super.dispose();
     }
 
@@ -154,113 +110,6 @@ export default class ScrollContainer extends ContainerObject {
     }
 
     /**
-     * Handles mouse events fired on events when the element being interacted with is outside
-     * the viewport
-     *
-     * The only reason we have to do this is because of a long-standing WebKit/Safari bug
-     * where events are fired on elements that cannot be seen with clip-path:
-     * https://bugs.webkit.org/show_bug.cgi?id=152548 This issue has since been resolved
-     * (tested as present with Safari on iOS 14.5, and resolved with Safari on iOS 15).
-     * This "hack" can be removed once we no longer need to support browsers running the older webkit
-     * (namely, once Safari on iOS 14.5-14.8 falls below 0.5%)
-     *
-     * An example of where this can be seen is when you solve a puzzle like 6502949 which has
-     * an image in its mission complete screen. If your window is short enough, the image will be
-     * masked by the clip-path, but if it's position is still over the next button, you would not
-     * be able to click the next button because the click would just land on the image which is
-     * over the canvas. Similarly if a link is masked but positioned over the next button, clicking
-     * the next button would click the link.
-     *
-     * @param e Pointer event being handled
-     */
-    private handlePossiblyMaskedEvent(e: MouseEvent | PointerEvent | WheelEvent): void {
-        const {
-            x, y, width, height
-        } = this.getBounds();
-
-        const isMaskedElement = this._htmlWrapper.contains(e.target as HTMLDivElement);
-
-        if (
-            isMaskedElement
-            && (e.clientX < x || e.clientX > x + width || e.clientY < y || e.clientY > y + height)
-        ) {
-            // This event was fired on a location outside our clip path, and because
-            // we register this callback for elements within our scroll panel, this must mean
-            // it should have been clipped.
-            e.preventDefault();
-            e.stopPropagation();
-
-            // Find the next element "under" this element that isn't in our scroll container,
-            // to re-fire the event on.
-            const candidateEls = document.elementsFromPoint(e.clientX, e.clientY);
-            const newTarget = candidateEls.find((el) => !this._htmlWrapper.contains(el));
-            if (!newTarget) return;
-
-            // If we transition from an unmasked portion of an overlay element to the masked portion,
-            // we won't trigger the pointerover event because the browser thinks we're still on
-            // the old element. As such, we need to make sure that actually happens properly
-            // eg for button hovering purposes
-            if (!this.lastEventWasMasked) {
-                this.lastEventWasMasked = true;
-                newTarget.dispatchEvent(new PointerEvent('pointerover', e));
-            }
-
-            if (e instanceof PointerEvent) {
-                newTarget.dispatchEvent(new PointerEvent(e.type, e));
-            } else if (e instanceof WheelEvent) {
-                newTarget.dispatchEvent(new WheelEvent(e.type, e));
-            } else {
-                newTarget.dispatchEvent(new MouseEvent(e.type, e));
-            }
-        } else if (this.lastEventWasMasked && !isMaskedElement) {
-            this.lastEventWasMasked = false;
-        }
-    }
-
-    /**
-     * Similar to handlePossiblyMaskedEvent.
-     *
-     * @param e Touch event to be handled
-     */
-    private handleTouchEvent(e: TouchEvent): void {
-        const {
-            x, y, width, height
-        } = this.getBounds();
-
-        const isMaskedElement = this._htmlWrapper.contains(e.target as HTMLDivElement);
-
-        const touch = e.changedTouches[0];
-        if (
-            isMaskedElement
-            && (
-                touch.clientX < x
-                || touch.clientX > x + width
-                || touch.clientY < y
-                || touch.clientY > y + height
-            )
-        ) {
-            // This event was fired on a location outside our clip path, and because
-            // we register this callback for elements within our scroll panel, this must mean
-            // it should have been clipped.
-            e.preventDefault();
-            e.stopPropagation();
-
-            // Find the next element "under" this element that isn't in our scroll container,
-            // to re-fire the event on.
-            const candidateEls = document.elementsFromPoint(touch.clientX, touch.clientY);
-            const newTarget = candidateEls.find((el) => !this._htmlWrapper.contains(el));
-            if (!newTarget) return;
-
-            newTarget.dispatchEvent(new TouchEvent(e.type, {
-                ...e,
-                touches: [...e.touches],
-                changedTouches: [...e.changedTouches],
-                targetTouches: [...e.targetTouches]
-            }));
-        }
-    }
-
-    /**
      * HTML wrapper element used to mask HTML children - all HTML content added to this
      * scroll container should be added as a child of this element
      */
@@ -275,10 +124,6 @@ export default class ScrollContainer extends ContainerObject {
 
     private readonly _contentMask = new Graphics();
     private _htmlWrapper: HTMLDivElement;
-
-    private _boundHTE: (e: TouchEvent) => void;
-    private _boundHME: (e: MouseEvent | PointerEvent) => void;
-    private lastEventWasMasked = false;
 
     private _width: number;
     private _height: number;


### PR DESCRIPTION
## Summary
Currently if you eg have the sequence field in the design browser part way offscreen and then paste a long sequence, if will cause the entire page to shift offscreen. This prevents that from happening

## Implementation Notes
By default, browsers move the page so that a focused input (and more specifically, your cursor) is in view. This makes sense, as you want to make sure you see what you're doing, and a keyboard user may be tabbing through input fields which should scroll into view, etc. However: a) scrolling the page is not actually what we want - we haven't actually drawn content there that's just sitting offscreen, it's only "virtually" in our scene and we'd actually need to redraw the scene and b) we have overflow: hidden on our root game element, which means that there is no good way to scroll the content back into view. Additionally, it may be in a ScrollContainer which has it clipped, which means it may not even show the input at all.

Arguably in some situations we should find a way to implement this behavior - eg, in a scroll container, we should just scroll the scroll container. However this is nontrivial, so will leave this to a future enhancement and limit this work to fixing the buggy behavior. See #820.

This patch also removes the input masking hack since we no longer need to support the misbehaving WebKit version, and that was getting in the way of debugging this issue.