### PR TITLE
Fix energy_of_structure_async not returning a promise

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1301,7 +1301,7 @@ export default class PoseEditMode extends GameMode {
 
         scriptInterfaceCtx.addCallback(
             'energy_of_structure_async',
-            (seq: string, secstruct: string): number | null => {
+            async (seq: string, secstruct: string): Promise<number | null> => {
                 if (this._folder === null) {
                     return null;
                 }


### PR DESCRIPTION
## Summary
Previously, the `energy_of_structure_async` Eternascript function was identical to `energy_of_structure`. Now, it is an async function returning a promise, as intended and described 

## Implementation Notes
While no folder currently exposes scoreStructures as async, which is why this did not lead to a type error, and there is nothing for us to await, we are exposing this async version to allow users to future-proof for situations where async access may be required.
