### PR TITLE
Add confidence metrics to specbox

### DIFF
--- a/src/eterna/folding/__tests__/FoldUtil.test.ts
+++ b/src/eterna/folding/__tests__/FoldUtil.test.ts
@@ -13,7 +13,7 @@ test('FoldUtil:tea', () => {
 
             const seq = Sequence.fromSequenceString('GGGGAAACCC');
             const bpps = eternafold.getDotPlot(seq);;
-            expect(FoldUtil.expectedAccuracy(
+            expect(FoldUtil.bppConfidence(
                 SecStruct.fromParens('(((....)))', false),
                 bpps,
                 BasePairProbabilityTransform.LEAVE_ALONE

--- a/src/eterna/ui/SpecBoxDialog.ts
+++ b/src/eterna/ui/SpecBoxDialog.ts
@@ -149,20 +149,14 @@ export default class SpecBoxDialog extends WindowDialog<void> {
             .append(`${Number(this._dataBlock.getParam(UndoBlockParam.MEANPUNP, TEMPERATURE, pseudoknots)).toFixed(3)}\t\t`)
             .append('Branchiness : ', 'bold')
             .append(`${Number(this._dataBlock.getParam(UndoBlockParam.BRANCHINESS, TEMPERATURE, pseudoknots)).toFixed(1)}\n`)
-            .append('Target exp acc : ', 'bold')
-            .append(`${(this._dataBlock.getParam(UndoBlockParam.TARGET_EXPECTED_ACCURACY, TEMPERATURE, pseudoknots) as number)?.toFixed(3) ?? 'Unavailable'}`);
-        const ef1 = this._dataBlock.getParam(UndoBlockParam.EF1, TEMPERATURE, pseudoknots);
-        if (ef1 != null) {
-            const ef1CrossPair = this._dataBlock.getParam(UndoBlockParam.EF1_CROSS_PAIR, TEMPERATURE, pseudoknots);
-            statString
-                .append('\n')
-                .append('eF1 : ', 'bold')
-                .append((ef1 as number).toFixed(3))
-                .append('\t\t')
-                .append('eF1,cross-pair : ', 'bold')
-                .append((ef1CrossPair as number).toFixed(3));
-        }
-
+            .append('Target Confidence (F1) : ', 'bold')
+            .append(`${(this._dataBlock.getParam(UndoBlockParam.BPP_F1_TARGET, TEMPERATURE, pseudoknots) as number)?.toFixed(3) ?? 'Unavailable'}\n`)
+            .append('Natural Confidence (F1) : ', 'bold')
+            .append(`${(this._dataBlock.getParam(UndoBlockParam.BPP_F1_NATIVE, TEMPERATURE, pseudoknots) as number)?.toFixed(3) ?? 'Unavailable'}\n`)
+            .append('PK-Masked Target Confidence (F1) : ', 'bold')
+            .append(`${(this._dataBlock.getParam(UndoBlockParam.BPP_F1_TARGET_PKMASK, TEMPERATURE, pseudoknots) as number)?.toFixed(3) ?? 'Unavailable'}\n`)
+            .append('PK-Natural Confidence (F1) : ', 'bold')
+            .append(`${(this._dataBlock.getParam(UndoBlockParam.BPP_F1_NATIVE_PKMASK, TEMPERATURE, pseudoknots) as number)?.toFixed(3) ?? 'Unavailable'}`);
         statString.apply(this._statText);
 
         if (this._dotPlot) this._dotPlot.destroy();


### PR DESCRIPTION
## Summary
Following the addition of the confidence constraints (https://github.com/eternagame/EternaJS/issues/791), these metrics are now being added to the specbox

Also, BPP-derived metrics are now always recomputed when doing a dot plot update, to avoid the situation where some metrics may have been cached, but not all of them (ie, due to the calculation being done on an old version of the code where they did not exist), leaving some of them to not be left empty.

## Implementation Notes
* eF1 is now removed since this is now the preferred metric. Its UndoBlockParam IDs are retained only for historical reference (note they can't be reused since there is saved data where these IDs already refer to eF1
* TEA is kept in the code to support the constraint, however removed from the specbox because its not meaningfully different than F1 target confidence
* The expectedAccuracy method is renamed to bppConfidence to avoid confusion/be more correct ("accuracy" is its own statistical metric - which we are not computing here!)
* All f1 calculations, not just masked ones, now return "0" in the case of no pairs (the rationale holds true in all cases)

## Testing
Verified numbers matched current version of constraints in the 6XRZ test puzzle