### PR TITLE
Fix structure modifications sometimes leaving half-paired bases

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -2190,6 +2190,11 @@ export default class PoseEditMode extends GameMode {
                 && structureConstraints[targetPartner] === false
                 // If this base is currently paired, its pair is unconstrained
                 && (pairs.pairingPartner(i) === -1 || structureConstraints[pairs.pairingPartner(i)] === false)
+                // If the base we're pairing with is currently paired, its pair is unconstrained
+                && (
+                    pairs.pairingPartner(targetPartner) === -1
+                    || structureConstraints[pairs.pairingPartner(targetPartner)] === false
+                )
             ) {
                 pairs.setPairingPartner(i, targetPartner);
             }
@@ -3973,6 +3978,9 @@ export default class PoseEditMode extends GameMode {
                         || (b !== -1 && structureConstraints[b])
                         // This base is currently paired to another base which cant have its structure changed
                         || (targetPairs.pairingPartner(a) !== -1 && structureConstraints[targetPairs.pairingPartner(a)])
+                        // The base we want to pair to is currently paired to another base which
+                        // cant have its structure changed
+                        || (b !== -1 && structureConstraints[targetPairs.pairingPartner(b)])
                     )
                 ) {
                     return false;

--- a/src/eterna/rnatypes/SecStruct.ts
+++ b/src/eterna/rnatypes/SecStruct.ts
@@ -67,7 +67,7 @@ export default class SecStruct {
     }
 
     /**
-     * Set the pairing partner to a particular value. If the position was
+     * Set the pairing partner to a particular value. If either position was
      * paired to begin with, unpair it first so we don't have an inconsistent
      * state.
      * @param index
@@ -77,7 +77,11 @@ export default class SecStruct {
         if (this.isPaired(index) && this.pairingPartner(index) !== pi) {
             this._pairs[this.pairingPartner(index)] = -1;
         }
+        if (this.isPaired(pi) && this.pairingPartner(pi) !== index) {
+            this._pairs[this.pairingPartner(pi)] = -1;
+        }
         this._pairs[index] = pi;
+        this._pairs[pi] = index;
     }
 
     /**
@@ -520,7 +524,6 @@ export default class SecStruct {
         const newStruct = new SecStruct(new Array(this.length).fill(-1));
         for (const pair of crossedPairs) {
             newStruct.setPairingPartner(pair[0], pair[1]);
-            newStruct.setPairingPartner(pair[1], pair[0]);
         }
         return newStruct;
     }


### PR DESCRIPTION
## Summary
This actually resolves a couple issues:
1) A crash when using the t-loop stamper
2) Potentially unknown bugs when using the t-loop stamper due to a partially corrupted internal structure representation
3) When using either the t-loop stamper or target structure paste, there is a chance you could violate structure constraints (when pairing bases a and b, we never checked if b is paired to c, that c is able to be made unpaired)

## Implementation Notes
Speaking to (1)/(2): What happened here is that the t-loop stamper was only configured to set pairs from 5' to 3' and not 3' to 5' (eg, in either stamp, we specified that the first base should be paired to the last base, but not that the last base should be paired to the first base). The crash occured if you stamped over an existing target structure such that whatever the second base was previously paired to was never unpaired. But also it meant that the internal pairmap was not symmetric, which could lead to some other issue later down the line.

Ultimately this was due to the fact that `SecStruct#setPairingPartner` was meant to be called twice, once in each direction. Presumably this was either an oversight or a performance optimization. That said, this has already bitten me before (see 0bf6132b4248859051b00021e5c19595d84a3e9f), and is not intuitive behavior. So I've updated this function to do the reasonable thing and just handle both directions by default. The performance penalty shouldn't be meaningful.

This inadvertently helped me realize (3) was an issue.