### PR TITLE
Allow tloop to be formed with sequence regions in any order

### DIFF
--- a/src/eterna/EPars.ts
+++ b/src/eterna/EPars.ts
@@ -39,8 +39,8 @@ export enum RNAPaint {
     MAGIC_GLUE = 20,
     BASE_MARK = 21,
     LIBRARY_SELECT = 22,
-    STAMP_TLOOP5 = 23,
-    STAMP_TLOOP3 = 24,
+    STAMP_TLOOPA = 23,
+    STAMP_TLOOPB = 24,
 }
 
 export default class EPars {

--- a/src/eterna/constraints/constraints/TLoopConstraint.ts
+++ b/src/eterna/constraints/constraints/TLoopConstraint.ts
@@ -16,17 +16,17 @@ interface TLoopConstraintStatus extends BaseConstraintStatus {
 // ((xxxxx[xx)) ((xx]xxxx))
 // Derived from the tRNA(phe)(E. coli) secondary structure (based on DSSR) from PDB ID 1EHZ
 // The bases marked "x" here may be paired or unpaired
-export const TLoop5Seq = Sequence.fromSequenceString('??AGUUGGGA??');
-export const TLoop3Seq = Sequence.fromSequenceString('??UUCGAUC??');
-export const TLoopPairs = (tloop5Start: number, tloop3Start: number) => [
+export const TLoopSeqA = Sequence.fromSequenceString('??AGUUGGGA??');
+export const TLoopSeqB = Sequence.fromSequenceString('??UUCGAUC??');
+export const TLoopPairs = (tloopAStart: number, tloopBStart: number) => [
     // Pair mappings within 5' region
-    [tloop5Start, tloop5Start + 11],
-    [tloop5Start + 1, tloop5Start + 10],
+    [tloopAStart, tloopAStart + 11],
+    [tloopAStart + 1, tloopAStart + 10],
     // Pair mappings within 3' region
-    [tloop3Start, tloop3Start + 10],
-    [tloop3Start + 1, tloop3Start + 9],
+    [tloopBStart, tloopBStart + 10],
+    [tloopBStart + 1, tloopBStart + 9],
     // Cross-region pairs
-    [tloop5Start + 7, tloop3Start + 4]
+    [tloopAStart + 7, tloopBStart + 4]
 ];
 
 export default class TLoopConstraint extends Constraint<TLoopConstraintStatus> {
@@ -40,16 +40,16 @@ export default class TLoopConstraint extends Constraint<TLoopConstraintStatus> {
         );
         const naturalPairs = undoBlock.getPairs(EPars.DEFAULT_TEMPERATURE, pseudoknots);
         const seq = undoBlock.sequence.toString();
-        const seqMatch5 = Array.from(seq.matchAll(new RegExp(TLoop5Seq.toString().replaceAll('?', '.'), 'g')));
-        const seqMatch3 = Array.from(seq.matchAll(new RegExp(TLoop3Seq.toString().replaceAll('?', '.'), 'g')));
+        const tloopASeqMatch = Array.from(seq.matchAll(new RegExp(TLoopSeqA.toString().replaceAll('?', '.'), 'g')));
+        const tloopBSeqMatch = Array.from(seq.matchAll(new RegExp(TLoopSeqB.toString().replaceAll('?', '.'), 'g')));
 
-        for (const candidate5 of seqMatch5) {
-            for (const candidate3 of seqMatch3) {
-                const c5Start = candidate5.index;
-                const c3Start = candidate3.index;
+        for (const candidateForA of tloopASeqMatch) {
+            for (const candidateForB of tloopBSeqMatch) {
+                const aStart = candidateForA.index;
+                const bStart = candidateForB.index;
                 if (
-                    (c5Start + TLoop5Seq.length - 1) < c3Start
-                    && TLoopPairs(c5Start, c3Start).every(
+                    (aStart + TLoopSeqA.length - 1) < bStart
+                    && TLoopPairs(aStart, bStart).every(
                         ([a, b]) => naturalPairs.pairingPartner(a) === b
                     )
                 ) {
@@ -64,8 +64,8 @@ export default class TLoopConstraint extends Constraint<TLoopConstraintStatus> {
 
         return {
             satisfied: false,
-            found5Prime: seqMatch5.length > 0,
-            found3Prime: seqMatch3.length > 0
+            found5Prime: tloopASeqMatch.length > 0,
+            found3Prime: tloopBSeqMatch.length > 0
         };
     }
 
@@ -97,11 +97,11 @@ export default class TLoopConstraint extends Constraint<TLoopConstraintStatus> {
             tooltip.pushStyle('altTextMain');
         }
 
-        tooltip.append(`Your design must contain the T-loop sequence (${TLoop5Seq.toString().replaceAll('?', 'N')}--${TLoop3Seq.toString().replaceAll('?', 'N')}) and form the T-loop structure`);
+        tooltip.append(`Your design must contain the T-loop sequence (${TLoopSeqA.toString().replaceAll('?', 'N')}--${TLoopSeqB.toString().replaceAll('?', 'N')}) and form the T-loop structure`);
         if (!forMissionScreen) {
-            tooltip.append(`\n\nThe T-loop 5' sequence ${TLoop5Seq.toString().replaceAll('?', 'N')} is currently `)
+            tooltip.append(`\n\nThe T-loop sequence ${TLoopSeqA.toString().replaceAll('?', 'N')} is currently `)
                 .append(status.found5Prime ? 'present' : 'missing', 'altText')
-                .append(`\n\nThe T-loop 3' sequence ${TLoop3Seq.toString().replaceAll('?', 'N')} is currently `)
+                .append(`\n\nThe T-loop sequence ${TLoopSeqB.toString().replaceAll('?', 'N')} is currently `)
                 .append(status.found3Prime ? 'present' : 'missing', 'altText')
                 .append('\n\nThe T-loop structure is currently ')
                 .append(status.satisfied ? 'forming' : 'not forming', 'altText');

--- a/src/eterna/constraints/constraints/TLoopConstraint.ts
+++ b/src/eterna/constraints/constraints/TLoopConstraint.ts
@@ -48,7 +48,11 @@ export default class TLoopConstraint extends Constraint<TLoopConstraintStatus> {
                 const aStart = candidateForA.index;
                 const bStart = candidateForB.index;
                 if (
-                    (aStart + TLoopSeqA.length - 1) < bStart
+                    // Ensure the two candidate regions do not overlap
+                    (
+                        (aStart + TLoopSeqA.length - 1) < bStart
+                        || (bStart + TLoopSeqB.length - 1) < aStart
+                    )
                     && TLoopPairs(aStart, bStart).every(
                         ([a, b]) => naturalPairs.pairingPartner(a) === b
                     )

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -83,7 +83,7 @@ import DotPlot from 'eterna/rnatypes/DotPlot';
 import UILockDialog from 'eterna/ui/UILockDialog';
 import Dialog from 'eterna/ui/Dialog';
 import WindowDialog from 'eterna/ui/WindowDialog';
-import TLoopConstraint, {TLoop3Seq, TLoop5Seq, TLoopPairs} from 'eterna/constraints/constraints/TLoopConstraint';
+import TLoopConstraint, {TLoopSeqB, TLoopSeqA, TLoopPairs} from 'eterna/constraints/constraints/TLoopConstraint';
 import GameMode from '../GameMode';
 import SubmittingDialog from './SubmittingDialog';
 import SubmitPoseDialog from './SubmitPoseDialog';
@@ -1084,12 +1084,12 @@ export default class PoseEditMode extends GameMode {
             this.setPosesColor(RNAPaint.MAGIC_GLUE);
         }));
 
-        this.regs.add(this._toolbar.stampTLoop5.clicked.connect(() => {
-            this.setPosesColor(RNAPaint.STAMP_TLOOP5);
+        this.regs.add(this._toolbar.stampTLoopA.clicked.connect(() => {
+            this.setPosesColor(RNAPaint.STAMP_TLOOPA);
         }));
 
-        this.regs.add(this._toolbar.stampTLoop3.clicked.connect(() => {
-            this.setPosesColor(RNAPaint.STAMP_TLOOP3);
+        this.regs.add(this._toolbar.stampTLoopB.clicked.connect(() => {
+            this.setPosesColor(RNAPaint.STAMP_TLOOPB);
         }));
 
         this.regs.add(this._toolbar.moveButton.clicked.connect(() => {
@@ -4000,43 +4000,43 @@ export default class PoseEditMode extends GameMode {
         };
 
         switch (lastStamp.type) {
-            case 'TLOOP5': {
-                if (canStampSeq(TLoop5Seq, lastStamp.baseIndex)) {
-                    stampSeq(TLoop5Seq, lastStamp.baseIndex);
+            case 'TLOOPA': {
+                if (canStampSeq(TLoopSeqA, lastStamp.baseIndex)) {
+                    stampSeq(TLoopSeqA, lastStamp.baseIndex);
                     if (
-                        this._lastStampedTLoop3 !== -1
+                        this._lastStampedTLoopB !== -1
                         // The opposing stamped sequence is still there
-                        && TLoop3Seq.baseArray.every(
+                        && TLoopSeqB.baseArray.every(
                             (base, idx) => (
                                 base === RNABase.UNDEFINED
-                                || fromPose.sequence.nt(this._lastStampedTLoop3 + idx) === base
+                                || fromPose.sequence.nt(this._lastStampedTLoopB + idx) === base
                             )
                         )
-                        && canStampStruct(TLoopPairs(lastStamp.baseIndex, this._lastStampedTLoop3))
+                        && canStampStruct(TLoopPairs(lastStamp.baseIndex, this._lastStampedTLoopB))
                     ) {
-                        stampStruct(TLoopPairs(lastStamp.baseIndex, this._lastStampedTLoop3));
+                        stampStruct(TLoopPairs(lastStamp.baseIndex, this._lastStampedTLoopB));
                     }
-                    this._lastStampedTLoop5 = lastStamp.baseIndex;
+                    this._lastStampedTLoopA = lastStamp.baseIndex;
                 }
                 break;
             }
-            case 'TLOOP3': {
-                if (canStampSeq(TLoop3Seq, lastStamp.baseIndex)) {
-                    stampSeq(TLoop3Seq, lastStamp.baseIndex);
+            case 'TLOOPB': {
+                if (canStampSeq(TLoopSeqB, lastStamp.baseIndex)) {
+                    stampSeq(TLoopSeqB, lastStamp.baseIndex);
                     if (
-                        this._lastStampedTLoop5 !== -1
+                        this._lastStampedTLoopA !== -1
                         // The opposing stamped sequence is still there
-                        && TLoop5Seq.baseArray.every(
+                        && TLoopSeqA.baseArray.every(
                             (base, idx) => (
                                 base === RNABase.UNDEFINED
-                                || fromPose.sequence.nt(this._lastStampedTLoop5 + idx) === base
+                                || fromPose.sequence.nt(this._lastStampedTLoopA + idx) === base
                             )
                         )
-                        && canStampStruct(TLoopPairs(this._lastStampedTLoop5, lastStamp.baseIndex))
+                        && canStampStruct(TLoopPairs(this._lastStampedTLoopA, lastStamp.baseIndex))
                     ) {
-                        stampStruct(TLoopPairs(this._lastStampedTLoop5, lastStamp.baseIndex));
+                        stampStruct(TLoopPairs(this._lastStampedTLoopA, lastStamp.baseIndex));
                     }
-                    this._lastStampedTLoop3 = lastStamp.baseIndex;
+                    this._lastStampedTLoopB = lastStamp.baseIndex;
                 }
                 break;
             }
@@ -4697,8 +4697,8 @@ export default class PoseEditMode extends GameMode {
     // Annotations
     private _annotationManager: AnnotationManager;
 
-    private _lastStampedTLoop5 = -1;
-    private _lastStampedTLoop3 = -1;
+    private _lastStampedTLoopA = -1;
+    private _lastStampedTLoopB = -1;
 
     private static readonly FOLDING_LOCK = 'Folding';
 }

--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -3351,7 +3351,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         return this._lastShiftedCommand;
     }
 
-    public get lastStamp(): {baseIndex: number; type: 'TLOOP3' | 'TLOOP5'} | null {
+    public get lastStamp(): {baseIndex: number; type: 'TLOOPA' | 'TLOOPB'} | null {
         return this._lastStamp;
     }
 
@@ -3552,10 +3552,10 @@ export default class Pose2D extends ContainerObject implements Updatable {
             if (this.toggleDesignStruct(seqnum)) {
                 this._designStructUpdated = true;
             }
-        } else if (this._currentColor === RNAPaint.STAMP_TLOOP5) {
-            this._lastStamp = {type: 'TLOOP5', baseIndex: seqnum};
-        } else if (this._currentColor === RNAPaint.STAMP_TLOOP3) {
-            this._lastStamp = {type: 'TLOOP3', baseIndex: seqnum};
+        } else if (this._currentColor === RNAPaint.STAMP_TLOOPA) {
+            this._lastStamp = {type: 'TLOOPA', baseIndex: seqnum};
+        } else if (this._currentColor === RNAPaint.STAMP_TLOOPB) {
+            this._lastStamp = {type: 'TLOOPB', baseIndex: seqnum};
         } else if (!this.isLocked(seqnum)) {
             if (
                 this._currentColor === RNABase.ADENINE || this._currentColor === RNABase.URACIL
@@ -4508,7 +4508,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
     private _lastShiftedCommand: number = -1;
 
     // Stamping
-    private _lastStamp: {baseIndex: number; type: 'TLOOP3' | 'TLOOP5'} | null = null;
+    private _lastStamp: {baseIndex: number; type: 'TLOOPA' | 'TLOOPB'} | null = null;
 
     // Rendering mode
     private _numberingMode: boolean = false;

--- a/src/eterna/ui/toolbar/Toolbar.ts
+++ b/src/eterna/ui/toolbar/Toolbar.ts
@@ -35,7 +35,7 @@ import {
     nucleotideRangeButtonProps, explosionFactorButtonProps, pipButtonProps, zoomInButtonProps,
     zoomOutButtonProps, view3DButtonProps, moveButtonProps, rotateStemButtonProps, flipStemButtonProps,
     snapToGridButtonProps, baseMarkerButtonProps, annotationModeButtonProps, annotationPanelButtonProps,
-    boostersMenuButtonProps, stampTLoop5MenuButtonProps, stampTLoop3MenuButtonProps
+    boostersMenuButtonProps, stampTLoopAMenuButtonProps, stampTLoopBMenuButtonProps
 } from './ToolbarButtons';
 import ToolShelf from './ToolShelf';
 
@@ -79,8 +79,8 @@ export default class Toolbar extends ContainerObject {
     public librarySelectionButton: ToolbarButton;
     public magicGlueButton: ToolbarButton;
     public boostersMenuButton: ToolbarButton;
-    public stampTLoop5: ToolbarButton;
-    public stampTLoop3: ToolbarButton;
+    public stampTLoopA: ToolbarButton;
+    public stampTLoopB: ToolbarButton;
     public dynPaintTools: ToolbarButton[] = [];
 
     // Import/Export
@@ -528,8 +528,8 @@ export default class Toolbar extends ContainerObject {
         this.librarySelectionButton = this.setupButton(librarySelectionButtonProps, this._showLibrarySelect);
         this.resetButton = this.setupButton(resetButtonProps, isEditable);
         this.magicGlueButton = this.setupButton(magicGlueButtonProps, this._showGlue);
-        this.stampTLoop5 = this.setupButton(stampTLoop5MenuButtonProps, this._showStampTLoop);
-        this.stampTLoop3 = this.setupButton(stampTLoop3MenuButtonProps, this._showStampTLoop);
+        this.stampTLoopA = this.setupButton(stampTLoopAMenuButtonProps, this._showStampTLoop);
+        this.stampTLoopB = this.setupButton(stampTLoopBMenuButtonProps, this._showStampTLoop);
         this.boostersMenuButton = this.setupButton(
             boostersMenuButtonProps,
             isEditable && this._boostersData !== null

--- a/src/eterna/ui/toolbar/ToolbarButtons.ts
+++ b/src/eterna/ui/toolbar/ToolbarButtons.ts
@@ -307,25 +307,25 @@ export const boostersMenuButtonProps: ToolbarParam = {
     rscriptID: RScriptUIElementID.BOOSTERS
 };
 
-export const stampTLoop5MenuButtonProps: ToolbarParam = {
+export const stampTLoopAMenuButtonProps: ToolbarParam = {
     cat: ButtonCategory.SOLVE,
-    id: 'stampTLoop5',
-    displayName: 'Stamp T-loop (5\')',
+    id: 'stampTLoopA',
+    displayName: 'Stamp T-loop (A)',
     allImg: Bitmaps.ImgStampTLoop,
     overImg: Bitmaps.ImgOverStampTLoop,
     disableImg: Bitmaps.ImgGreyStampTLoop,
-    tooltip: 'Stamp T-loop (5\')',
+    tooltip: 'Stamp T-loop (A)',
     isPaintTool: true
 };
 
-export const stampTLoop3MenuButtonProps: ToolbarParam = {
+export const stampTLoopBMenuButtonProps: ToolbarParam = {
     cat: ButtonCategory.SOLVE,
-    id: 'stampTLoop3',
-    displayName: 'Stamp T-loop (3\')',
+    id: 'stampTLoopB',
+    displayName: 'Stamp T-loop (B)',
     allImg: Bitmaps.ImgStampTLoop,
     overImg: Bitmaps.ImgOverStampTLoop,
     disableImg: Bitmaps.ImgGreyStampTLoop,
-    tooltip: 'Stamp T-loop (3\')',
+    tooltip: 'Stamp T-loop (B)',
     isPaintTool: true
 };
 


### PR DESCRIPTION
Discussed with Rhiju. Originally I had the impression that one of the sequences should always be before the other, but they can actually be in either order. The stamper already inadvertently stamped the structure in both orders, but now the constraint also allows it (and the UI + code is updated to refer to the two regions as a and b rather than 5' and 3')
