### PR TITLE
Dont allow p(unpaired) to be less than 0

### DIFF
--- a/src/eterna/folding/FoldUtil.ts
+++ b/src/eterna/folding/FoldUtil.ts
@@ -70,17 +70,20 @@ export default class FoldUtil {
     public static pUnpaired(dotArray: DotPlot, seq: Sequence, behavior: BasePairProbabilityTransform) {
         // dotArray is organized as idx, idx, pairprob.
         const probUnpaired: number[] = Array<number>(seq.length);
-        const probUnpairedTrk: number[][] = Array<number[]>(seq.length);
         for (let idx = 0; idx < seq.length; ++idx) {
             probUnpaired[idx] = 1;
-            probUnpairedTrk[idx] = [];
             for (let ii = 0; ii < dotArray.data.length; ii += 3) {
                 if (dotArray.data[ii] === idx + 1 || dotArray.data[ii + 1] === idx + 1) {
                     if (behavior === BasePairProbabilityTransform.LEAVE_ALONE) {
-                        probUnpairedTrk[idx].push((dotArray.data[ii + 2]));
-                        probUnpaired[idx] -= (dotArray.data[ii + 2]);
+                        probUnpaired[idx] -= Math.min(
+                            (dotArray.data[ii + 2]),
+                            probUnpaired[idx]
+                        );
                     } else {
-                        probUnpaired[idx] -= (dotArray.data[ii + 2] * dotArray.data[ii + 2]);
+                        probUnpaired[idx] -= Math.min(
+                            (dotArray.data[ii + 2] * dotArray.data[ii + 2]),
+                            probUnpaired[idx]
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Conventionally, dot plots are probability matrices such that for any base, the probability that it will pair with any other base will sum to 1, less the probability that it is unpaired - with probability unpaired excluded, so to get the probability unpaired we sum and subtract from 1. However for an algorithm like ribonanzanet, the dot plot is instead a likelihood matrix such that the liklihood of each pair is independent of every other pair, meaning it could sum to more than 1. We now clip P(unp) to so that if the row sums to a value > 1, we don't drop p(unp) to be below 0, which doesn't make sense (it is still ambiguous what p(unp) should be if you have two pairs at .75 liklihood, but this is at least _better_).

This reflects a change made in https://github.com/DasLab/arnie/pull/50