### PR TITLE
Support padded experimental data

### DIFF
--- a/src/eterna/rnatypes/SecStruct.ts
+++ b/src/eterna/rnatypes/SecStruct.ts
@@ -552,7 +552,18 @@ export default class SecStruct {
         const pairsB = this._pairs.slice(start, end);
 
         for (let ii = 0; ii < pairsB.length; ii++) {
-            if (pairsB[ii] >= 0) pairsB[ii] -= start;
+            if (pairsB[ii] >= 0) {
+                if (
+                    pairsB[ii] - start < 0
+                    || (end !== undefined && pairsB[ii] >= end)
+                ) {
+                    // The pairing partner for this base no longer exists (it was sliced
+                    // off one of the ends), remove it
+                    pairsB[ii] = -1;
+                } else {
+                    pairsB[ii] -= start;
+                }
+            }
         }
 
         return new SecStruct(pairsB);


### PR DESCRIPTION
## Summary
In some of our recent labs (eg OpenKnot round 4) padding, barcodes, and tails are not included in the puzzle, instead being added as part of the synthesis process. We want to support the raw, un-trimmed data to be uploaded to Eterna. This is partially so that at a later date we could actually show this information, but for now as a practical implementation matter (we can't do it in the scoring pipeline without creating an invalid RDAT, and the backend does not have access to the code necessary to properly trim the estimate structures).

## Implementation Notes
The simplest path forward here appeared to be modifying the data on load rather than actually supporting visualizing the data at a given location. Naturally this would need to be adjusted if we decide to display the full data.

This has also uncovered a bug in `SecStruct#slice`, but I believe no existing code ran into it due to existing usage either not doing any trimming or only taking subsets of structures which had no pairings outside the selected region.