### PR TITLE
Support user event monitoring

### DIFF
--- a/src/eterna/Eterna.ts
+++ b/src/eterna/Eterna.ts
@@ -5,6 +5,7 @@ import EternaApp from 'eterna/EternaApp';
 import EternaSettings from './settings/EternaSettings';
 import GameClient from './net/GameClient';
 import ErrorDialogMode from './mode/ErrorDialogMode';
+import ObservabilityManager from './observability/ObservabilityManager';
 
 /** Return env.APP_SERVER_URL; if unspecified, default to window.location.origin */
 function GetServerURL(): string {
@@ -38,6 +39,7 @@ export default class Eterna {
     public static saveManager: SaveGameManager;
     public static client: GameClient;
     public static chat: ChatManager;
+    public static observability: ObservabilityManager;
 
     public static playerID: number;
     public static playerName: string;

--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -128,10 +128,6 @@ interface ProcessedEternaAppParams extends EternaAppParams {
 
 /** Entry point for the game */
 export default class EternaApp extends FlashbangApp {
-    get o11y() {
-        return Eterna.observability;
-    }
-
     constructor(params: EternaAppParams) {
         super();
 

--- a/src/eterna/EternaApp.ts
+++ b/src/eterna/EternaApp.ts
@@ -45,6 +45,7 @@ import ROPWait from './rscript/ROPWait';
 import Band from './ui/Band';
 import BaseGlow from './vfx/BaseGlow';
 import RNet from './folding/RNet';
+import ObservabilityManager from './observability/ObservabilityManager';
 
 export enum PuzzleID {
     FunAndEasy = 4350940,
@@ -127,6 +128,10 @@ interface ProcessedEternaAppParams extends EternaAppParams {
 
 /** Entry point for the game */
 export default class EternaApp extends FlashbangApp {
+    get o11y() {
+        return Eterna.observability;
+    }
+
     constructor(params: EternaAppParams) {
         super();
 
@@ -211,6 +216,7 @@ export default class EternaApp extends FlashbangApp {
         Eterna.gameDiv = document.getElementById(this._params.containerID);
         Eterna.noGame = this._params.noGame;
         Eterna.experimentalFeatures = this._params.experimentalFeatures;
+        Eterna.observability = new ObservabilityManager();
 
         // Without this, we stop the pointer events from propagating to NGL in Pose3D/PointerEventPropagator,
         // but the original mouse events will still get fired, so NGL will get confused since it tracks some

--- a/src/eterna/mode/DesignBrowser/DesignBrowserMode.ts
+++ b/src/eterna/mode/DesignBrowser/DesignBrowserMode.ts
@@ -384,6 +384,7 @@ export default class DesignBrowserMode extends GameMode {
 
     protected enter(): void {
         super.enter();
+        Eterna.observability.recordEvent('ModeEnter', {mode: 'DesignBrowser', puzzle: this._puzzle.nodeID});
         this.refreshSolutions();
         const {existingPoseEditMode} = Eterna.app;
         this._returnToGameButton.display.visible = (

--- a/src/eterna/mode/ErrorDialogMode.ts
+++ b/src/eterna/mode/ErrorDialogMode.ts
@@ -5,6 +5,7 @@ import {
 import Fonts from 'eterna/util/Fonts';
 import GameButton from 'eterna/ui/GameButton';
 import GameWindow from 'eterna/ui/GameWindow';
+import Eterna from 'eterna/Eterna';
 
 export default class ErrorDialogMode extends AppMode {
     public readonly error: Error | ErrorEvent;
@@ -109,6 +110,10 @@ export default class ErrorDialogMode extends AppMode {
         updateView();
         Assert.assertIsDefined(this.regs);
         this.regs.add(this.resized.connect(updateView));
+    }
+
+    protected enter() {
+        Eterna.observability.recordEvent('ModeEnter', {mode: 'ErrorDialog'});
     }
 
     private readonly _title: string;

--- a/src/eterna/mode/FeedbackViewMode.ts
+++ b/src/eterna/mode/FeedbackViewMode.ts
@@ -261,6 +261,10 @@ export default class FeedbackViewMode extends GameMode {
         this.updateUILayout();
     }
 
+    protected enter() {
+        Eterna.observability.recordEvent('ModeEnter', {mode: 'FeedbackView', puzzle: this._puzzle.nodeID});
+    }
+
     private setSolution(solution: Solution) {
         this._solution = solution;
         this._sequence = solution.sequence.slice(0);

--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -688,6 +688,7 @@ export default abstract class GameMode extends AppMode {
         // Already live
         if (!factorDialog) return;
         factorDialog.factor.connect((factor) => {
+            Eterna.observability.recordEvent('Display:ExplosionFactor', {factor});
             this._poseFields.forEach((pf) => { pf.explosionFactor = factor; });
         });
     }
@@ -742,17 +743,16 @@ export default abstract class GameMode extends AppMode {
             } else if (!ctrl && key === KeyCode.KeyL) {
                 Eterna.settings.usePuzzlerLayout.value = !Eterna.settings.usePuzzlerLayout.value;
                 handled = true;
-            } else if (ctrl && key === KeyCode.KeyS) {
-                this.downloadSVG();
-                handled = true;
             } else if (key === KeyCode.BracketLeft) {
                 const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor - 0.25) * 1000) / 1000);
+                Eterna.observability.recordEvent('Display:ExplosionFactor', {factor});
                 for (const pf of this._poseFields) {
                     pf.explosionFactor = factor;
                 }
                 handled = true;
             } else if (key === KeyCode.BracketRight) {
                 const factor = Math.max(0, Math.round((this._poseFields[0].explosionFactor + 0.25) * 1000) / 1000);
+                Eterna.observability.recordEvent('Display:ExplosionFactor', {factor});
                 for (const pf of this._poseFields) {
                     pf.explosionFactor = factor;
                 }

--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -644,6 +644,7 @@ export default abstract class GameMode extends AppMode {
         // Already live
         if (!pasteDialog) return;
         pasteDialog.applyClicked.connect((sequence) => {
+            Eterna.observability.recordEvent('RunTool:PasteSequence');
             this.pasteSequence(sequence);
         });
     }
@@ -653,6 +654,7 @@ export default abstract class GameMode extends AppMode {
         // Already live
         if (!finder) return;
         finder.jumpClicked.connect((baseNum) => {
+            Eterna.observability.recordEvent('Display:JumpToNt');
             if (this._isPipMode) {
                 this._poses.forEach((p) => p.focusNucleotide(baseNum));
             } else {
@@ -662,6 +664,7 @@ export default abstract class GameMode extends AppMode {
     }
 
     protected showNucleotideRange(): void {
+        Eterna.observability.recordEvent('Display:ShowRange');
         const fullRange: [number, number] = [
             1,
             Math.max(...this._poses.map((p) => p.fullSequenceLength))

--- a/src/eterna/mode/PoseEdit/Booster.ts
+++ b/src/eterna/mode/PoseEdit/Booster.ts
@@ -137,6 +137,10 @@ export default class Booster {
         return this._buttonStateTextures;
     }
 
+    public get scriptID() {
+        return this._scriptID;
+    }
+
     public onLoad(): void {
         this.executeScript(null, 'ON_LOAD', -1);
     }

--- a/src/eterna/mode/PoseEdit/MissionIntroMode.ts
+++ b/src/eterna/mode/PoseEdit/MissionIntroMode.ts
@@ -134,6 +134,7 @@ export default class MissionIntroMode extends AppMode {
 
     protected enter(): void {
         super.enter();
+        Eterna.observability.recordEvent('ModeEnter', {mode: 'MissionIntro'});
         Eterna.chat.pushHideChat();
     }
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -264,6 +264,7 @@ export default class PoseEditMode extends GameMode {
 
     protected enter(): void {
         super.enter();
+        Eterna.observability.recordEvent('ModeEnter', {mode: 'PoseEdit', puzzle: this._puzzle.nodeID});
         this.hideAsyncText();
     }
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -1600,6 +1600,7 @@ export default class PoseEditMode extends GameMode {
             const ctrl = e.ctrlKey;
 
             if (ctrl && key === KeyCode.KeyZ) {
+                Eterna.observability.recordEvent('RunTool:lastStable');
                 this.moveUndoStackToLastStable();
                 handled = true;
             }

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -464,6 +464,7 @@ export default class PoseEditMode extends GameMode {
     }
 
     public onHintClicked(): void {
+        Eterna.observability.recordEvent('RunTool:Hint');
         if (this._hintBoxRef.isLive) {
             this._hintBoxRef.destroyObject();
         } else {
@@ -473,6 +474,7 @@ export default class PoseEditMode extends GameMode {
     }
 
     private onHelpClicked() {
+        Eterna.observability.recordEvent('RunTool:Help');
         const getBounds = (elem: ContainerObject) => {
             const globalPos = elem.container.toGlobal(new Point());
             return new Rectangle(
@@ -580,6 +582,7 @@ export default class PoseEditMode extends GameMode {
     }
 
     private setMarkerLayer(layer: string) {
+        Eterna.observability.recordEvent('RunTool:MarkerLayer', {layer});
         for (const pose of this._poses) {
             pose.setMarkerLayer(layer);
         }
@@ -809,6 +812,7 @@ export default class PoseEditMode extends GameMode {
             this._puzzle.puzzleType === PuzzleType.EXPERIMENTAL
         );
         this._folderSwitcher.selectedFolder.connectNotify((folder) => {
+            Eterna.observability.recordEvent('RunTool:ChangeFolder', {folder});
             for (const pose of this._poses) {
                 pose.scoreFolder = folder;
             }
@@ -1622,7 +1626,7 @@ export default class PoseEditMode extends GameMode {
             const ctrl = e.ctrlKey;
 
             if (ctrl && key === KeyCode.KeyZ) {
-                Eterna.observability.recordEvent('RunTool:lastStable');
+                Eterna.observability.recordEvent('RunTool:LastStable');
                 this.moveUndoStackToLastStable();
                 handled = true;
             }

--- a/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
+++ b/src/eterna/mode/PuzzleEdit/PuzzleEditMode.ts
@@ -412,6 +412,10 @@ export default class PuzzleEditMode extends GameMode {
         }
     }
 
+    protected enter() {
+        Eterna.observability.recordEvent('ModeEnter', {mode: 'PuzzleEdit'});
+    }
+
     private canUseFolder(folder: Folder) {
         const pseudoknots = this._structureInputs.some(
             (input) => SecStruct.fromParens(input.structureString, true).onlyPseudoknots().nonempty()

--- a/src/eterna/observability/ConsoleReporter.ts
+++ b/src/eterna/observability/ConsoleReporter.ts
@@ -1,0 +1,8 @@
+import log from 'loglevel';
+import ObservabilityReporter from './ObservabilityReporter';
+
+export default class ConsoleReporter implements ObservabilityReporter {
+    public recordEvent(event: {name: string, details?: unknown}) {
+        log.debug('EVENT', event);
+    }
+}

--- a/src/eterna/observability/ConsoleReporter.ts
+++ b/src/eterna/observability/ConsoleReporter.ts
@@ -3,6 +3,6 @@ import ObservabilityReporter from './ObservabilityReporter';
 
 export default class ConsoleReporter implements ObservabilityReporter {
     public recordEvent(event: {name: string, details?: unknown}) {
-        log.debug('EVENT', event);
+        log.debug('O11Y EVENT', event);
     }
 }

--- a/src/eterna/observability/ObservabilityManager.ts
+++ b/src/eterna/observability/ObservabilityManager.ts
@@ -1,0 +1,3 @@
+export default class ObservabilityManager {
+
+}

--- a/src/eterna/observability/ObservabilityManager.ts
+++ b/src/eterna/observability/ObservabilityManager.ts
@@ -1,3 +1,53 @@
-export default class ObservabilityManager {
+class ObservabilityEvent {
+    constructor(name: string, details: unknown) {
+        this.name = name;
+        this.details = details;
+    }
 
+    public readonly name: string;
+    public readonly details: unknown;
+    public next: ObservabilityEvent | null;
+}
+
+class RootEvent {
+    public next: ObservabilityEvent | null;
+}
+
+export class ObservabilityEventCapture {
+    constructor(firstEvent: ObservabilityEvent | RootEvent) {
+        this._firstEvent = firstEvent;
+    }
+
+    public report() {
+        const out = [];
+        let ev = this._firstEvent.next;
+        while (ev) {
+            if (ev.details !== undefined) {
+                out.push({name: ev.name, details: ev.details});
+            } else {
+                out.push({name: ev.name});
+            }
+            ev = ev.next;
+        }
+        return out;
+    }
+
+    private _firstEvent: ObservabilityEvent | RootEvent;
+}
+
+export default class ObservabilityManager {
+    public eventCapture(): ObservabilityEventCapture {
+        const capture = new ObservabilityEventCapture(this._lastEvent);
+        return capture;
+    }
+
+    public recordEvent(name: string, details?: unknown) {
+        const event = new ObservabilityEvent(name, details);
+        if (this._lastEvent) {
+            this._lastEvent.next = event;
+        }
+        this._lastEvent = event;
+    }
+
+    private _lastEvent: ObservabilityEvent | RootEvent = new RootEvent();
 }

--- a/src/eterna/observability/ObservabilityManager.ts
+++ b/src/eterna/observability/ObservabilityManager.ts
@@ -1,53 +1,30 @@
-class ObservabilityEvent {
-    constructor(name: string, details: unknown) {
-        this.name = name;
-        this.details = details;
-    }
+import ObservabilityReporter from './ObservabilityReporter';
 
-    public readonly name: string;
-    public readonly details: unknown;
-    public next: ObservabilityEvent | null;
-}
-
-class RootEvent {
-    public next: ObservabilityEvent | null;
-}
-
-export class ObservabilityEventCapture {
-    constructor(firstEvent: ObservabilityEvent | RootEvent) {
-        this._firstEvent = firstEvent;
-    }
-
-    public report() {
-        const out = [];
-        let ev = this._firstEvent.next;
-        while (ev) {
-            if (ev.details !== undefined) {
-                out.push({name: ev.name, details: ev.details});
-            } else {
-                out.push({name: ev.name});
-            }
-            ev = ev.next;
-        }
-        return out;
-    }
-
-    private _firstEvent: ObservabilityEvent | RootEvent;
+interface ObservabilityCapture {
+    reporter: ObservabilityReporter;
+    filter?: (event: {name: string, details?: unknown}) => boolean;
 }
 
 export default class ObservabilityManager {
-    public eventCapture(): ObservabilityEventCapture {
-        const capture = new ObservabilityEventCapture(this._lastEvent);
-        return capture;
+    public startCapture(
+        reporter: ObservabilityReporter,
+        filter?: ObservabilityCapture['filter']
+    ) {
+        this._captures.push({reporter, filter});
+    }
+
+    public endCapture(reporter: ObservabilityReporter) {
+        this._captures = this._captures.filter((capture) => capture.reporter !== reporter);
     }
 
     public recordEvent(name: string, details?: unknown) {
-        const event = new ObservabilityEvent(name, details);
-        if (this._lastEvent) {
-            this._lastEvent.next = event;
+        for (const capture of this._captures) {
+            if (!capture.filter || capture.filter({name, details})) {
+                if (details !== undefined) capture.reporter.recordEvent({name, details});
+                else capture.reporter.recordEvent({name});
+            }
         }
-        this._lastEvent = event;
     }
 
-    private _lastEvent: ObservabilityEvent | RootEvent = new RootEvent();
+    private _captures: ObservabilityCapture[] = [];
 }

--- a/src/eterna/observability/ObservabilityReporter.ts
+++ b/src/eterna/observability/ObservabilityReporter.ts
@@ -1,3 +1,3 @@
-export default abstract class ObservabilityReporter {
-    abstract recordEvent(event: {name: string, details?: unknown}): void;
+export default interface ObservabilityReporter {
+    recordEvent(event: {name: string, details?: unknown}): void;
 }

--- a/src/eterna/observability/ObservabilityReporter.ts
+++ b/src/eterna/observability/ObservabilityReporter.ts
@@ -1,0 +1,3 @@
+export default abstract class ObservabilityReporter {
+    abstract recordEvent(event: {name: string, details?: unknown}): void;
+}

--- a/src/eterna/observability/PostMessageReporter.ts
+++ b/src/eterna/observability/PostMessageReporter.ts
@@ -1,4 +1,6 @@
-export default class PostMessageReporter {
+import ObservabilityReporter from './ObservabilityReporter';
+
+export default class PostMessageReporter implements ObservabilityReporter {
     constructor(id: string, targetOrigin?: string) {
         this._id = id;
         this._targetOrigin = targetOrigin;

--- a/src/eterna/observability/PostMessageReporter.ts
+++ b/src/eterna/observability/PostMessageReporter.ts
@@ -1,0 +1,17 @@
+export default class PostMessageReporter {
+    constructor(id: string, targetOrigin?: string) {
+        this._id = id;
+        this._targetOrigin = targetOrigin;
+    }
+
+    public recordEvent(event: {name: string, details?: unknown}) {
+        window.postMessage({
+            type: 'observability-event',
+            reporterId: this._id,
+            event
+        }, {targetOrigin: this._targetOrigin});
+    }
+
+    private _id: string;
+    private _targetOrigin?: string;
+}

--- a/src/eterna/observability/__tests__/ObservabilityManager.test.ts
+++ b/src/eterna/observability/__tests__/ObservabilityManager.test.ts
@@ -3,7 +3,7 @@ import ObservabilityManager from '../ObservabilityManager';
 import ObservabilityReporter from '../ObservabilityReporter';
 
 function createReporter() {
-  class NullReporter extends ObservabilityReporter {
+  class NullReporter implements ObservabilityReporter {
     recordEvent = jest.fn();
   }
   return new NullReporter();

--- a/src/eterna/observability/__tests__/ObservabilityManager.test.ts
+++ b/src/eterna/observability/__tests__/ObservabilityManager.test.ts
@@ -1,0 +1,101 @@
+import ObservabilityManager from '../ObservabilityManager';
+
+test('ObservabilityCapture - immediate capture', () => {
+    const om = new ObservabilityManager();
+    const cap = om.eventCapture();
+    om.recordEvent('FIRST', {a:1, b:2, c:3});
+    om.recordEvent('SECOND');
+    expect(cap.report()).toMatchInlineSnapshot(`
+[
+  {
+    "details": {
+      "a": 1,
+      "b": 2,
+      "c": 3,
+    },
+    "name": "FIRST",
+  },
+  {
+    "name": "SECOND",
+  },
+]
+`)
+})
+
+test('ObservabilityCapture - skipped event', () => {
+    const om = new ObservabilityManager();
+    om.recordEvent('FIRST', {});
+    const cap = om.eventCapture();
+    om.recordEvent('SECOND', {});
+    om.recordEvent('THIRD', {});
+    expect(cap.report()).toMatchInlineSnapshot(`
+[
+  {
+    "details": {},
+    "name": "SECOND",
+  },
+  {
+    "details": {},
+    "name": "THIRD",
+  },
+]
+`)
+})
+
+test('ObservabilityCapture - mixed lifetimes', () => {
+    const om = new ObservabilityManager();
+    om.recordEvent('FIRST', {});
+    const cap = om.eventCapture();
+    om.recordEvent('SECOND', {});
+    const cap2 = om.eventCapture();
+    om.recordEvent('THIRD', {});
+    expect(cap.report()).toMatchInlineSnapshot(`
+[
+  {
+    "details": {},
+    "name": "SECOND",
+  },
+  {
+    "details": {},
+    "name": "THIRD",
+  },
+]
+`)
+    expect(cap2.report()).toMatchInlineSnapshot(`
+[
+  {
+    "details": {},
+    "name": "THIRD",
+  },
+]
+`)
+})
+
+test('ObservabilityCapture - mixed lifetimes', () => {
+    const om = new ObservabilityManager();
+    om.recordEvent('FIRST', {});
+    const cap = om.eventCapture();
+    om.recordEvent('SECOND', {});
+    const cap2 = om.eventCapture();
+    om.recordEvent('THIRD', {});
+    expect(cap.report()).toMatchInlineSnapshot(`
+[
+  {
+    "details": {},
+    "name": "SECOND",
+  },
+  {
+    "details": {},
+    "name": "THIRD",
+  },
+]
+`)
+    expect(cap2.report()).toMatchInlineSnapshot(`
+[
+  {
+    "details": {},
+    "name": "THIRD",
+  },
+]
+`)
+})

--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -890,12 +890,15 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this.addObject(dragger);
 
                 if (this._currentArrangementTool === Layout.MOVE) {
+                    Eterna.observability.recordEvent('Base:LayoutMove');
                     dragger.dragged.connect((p) => {
                         this.onMouseMoved(p as Point, closestIndex);
                     });
                 } else if (this._currentArrangementTool === Layout.ROTATE_STEM) {
+                    Eterna.observability.recordEvent('Base:LayoutRotate');
                     this.rotateStem(closestIndex);
                 } else if (this._currentArrangementTool === Layout.FLIP_STEM) {
+                    Eterna.observability.recordEvent('Base:LayoutFlip');
                     this.flipStem(closestIndex);
                 }
                 dragger.dragComplete.connect(() => {
@@ -908,6 +911,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 && closestIndex < this.fullSequenceLength
                 && !this._annotationManager.annotationModeActive.value
             ) {
+                Eterna.observability.recordEvent('Base:Mark');
                 this.toggleBaseMark(closestIndex);
                 return;
             }
@@ -928,6 +932,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 return;
             }
             if (this._annotationManager.annotationModeActive.value) {
+                Eterna.observability.recordEvent('Base:Annotate');
                 this.hideAnnotationContextMenu();
 
                 const strand = this.getStrandLabel(closestIndex) ?? undefined;
@@ -1042,6 +1047,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this._lastShiftedCommand = this._currentColor;
                 this._lastShiftedIndex = closestIndex;
 
+                Eterna.observability.recordEvent(`Base:${cmd[1]}`);
                 this.callAddBaseCallback(cmd[0], cmd[1], closestIndex);
             }
 
@@ -1069,6 +1075,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 && closestIndex < this.fullSequenceLength
                 && !this._annotationManager.annotationModeActive.value
             ) {
+                Eterna.observability.recordEvent('Base:Mark');
                 this.toggleBaseMark(closestIndex);
                 return;
             }
@@ -1082,6 +1089,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this._lastShiftedCommand = this._currentColor;
                 this._lastShiftedIndex = closestIndex;
 
+                Eterna.observability.recordEvent(`Base:${cmd[1]}`);
                 this.callAddBaseCallback(cmd[0], cmd[1], closestIndex);
             }
         }
@@ -1548,6 +1556,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         if (q == null) {
             return;
         }
+        Eterna.observability.recordEvent('Base:Shift3');
 
         const first: number = q[0];
         const last: number = q[1];
@@ -1612,6 +1621,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         if (q == null) {
             return;
         }
+        Eterna.observability.recordEvent('Base:Shift5');
 
         const first: number = q[0];
         const last: number = q[1];
@@ -3510,6 +3520,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         this._mutatedSequence = this.fullSequence.slice(0);
 
         if (this._currentColor === RNAPaint.LOCK) {
+            Eterna.observability.recordEvent('Base:Lock');
             if (!this._locks) {
                 this._locks = [];
                 for (let ii = 0; ii < this._sequence.length; ii++) {
@@ -3520,6 +3531,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
             this._bases[seqnum].setDirty();
             this._lockUpdated = true;
         } else if (this._currentColor === RNAPaint.BINDING_SITE) {
+            Eterna.observability.recordEvent('Base:BindingSite');
             if (!this._canAddBindingSite) {
                 (this.mode as GameMode).showNotification('The current folding engine does not support molecules');
             } else if (this._bindingSite != null && this._bindingSite[seqnum]) {
@@ -3549,22 +3561,27 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 }
             }
         } else if (this._mouseDownAltKey || this._currentColor === RNAPaint.MAGIC_GLUE) {
+            Eterna.observability.recordEvent('Base:Glue');
             if (this.toggleDesignStruct(seqnum)) {
                 this._designStructUpdated = true;
             }
         } else if (this._currentColor === RNAPaint.STAMP_TLOOPA) {
+            Eterna.observability.recordEvent('Base:TLoopA');
             this._lastStamp = {type: 'TLOOPA', baseIndex: seqnum};
         } else if (this._currentColor === RNAPaint.STAMP_TLOOPB) {
+            Eterna.observability.recordEvent('Base:TLoopB');
             this._lastStamp = {type: 'TLOOPB', baseIndex: seqnum};
         } else if (!this.isLocked(seqnum)) {
             if (
                 this._currentColor === RNABase.ADENINE || this._currentColor === RNABase.URACIL
                 || this._currentColor === RNABase.GUANINE || this._currentColor === RNABase.CYTOSINE
             ) {
+                Eterna.observability.recordEvent(`Base:${EPars.nucleotideToString(this._currentColor)}`);
                 this._mutatedSequence.setNt(seqnum, this._currentColor);
                 ROPWait.notifyPaint(seqnum, this._bases[seqnum].type, this._currentColor);
                 this._bases[seqnum].setType(this._currentColor, true);
             } else if (this._currentColor === RNAPaint.PAIR && this._pairs.isPaired(seqnum)) {
+                Eterna.observability.recordEvent('Base:Swap');
                 const pi = this._pairs.pairingPartner(seqnum);
                 if (this.isLocked(pi)) {
                     return;
@@ -3578,6 +3595,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this._bases[seqnum].setType(this._mutatedSequence.nt(seqnum), true);
                 this._bases[pi].setType(this._mutatedSequence.nt(pi), true);
             } else if (this._currentColor === RNAPaint.AU_PAIR && this._pairs.isPaired(seqnum)) {
+                Eterna.observability.recordEvent('Base:AuPair');
                 const pi = this._pairs.pairingPartner(seqnum);
                 if (this.isLocked(pi)) {
                     return;
@@ -3589,6 +3607,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this._bases[seqnum].setType(this._mutatedSequence.nt(seqnum), true);
                 this._bases[pi].setType(this._mutatedSequence.nt(pi), true);
             } else if (this._currentColor === RNAPaint.GC_PAIR && this._pairs.isPaired(seqnum)) {
+                Eterna.observability.recordEvent('Base:GcPair');
                 const pi = this._pairs.pairingPartner(seqnum);
                 if (this.isLocked(pi)) {
                     return;
@@ -3600,6 +3619,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this._bases[seqnum].setType(this._mutatedSequence.nt(seqnum), true);
                 this._bases[pi].setType(this._mutatedSequence.nt(pi), true);
             } else if (this._currentColor === RNAPaint.GU_PAIR && this._pairs.isPaired(seqnum)) {
+                Eterna.observability.recordEvent('Base:GuPair');
                 const pi = this._pairs.pairingPartner(seqnum);
                 if (this.isLocked(pi)) {
                     return;
@@ -3612,8 +3632,10 @@ export default class Pose2D extends ContainerObject implements Updatable {
                 this._bases[pi].setType(this._mutatedSequence.nt(pi), true);
             } else if (this._dynPaintColors.indexOf(this._currentColor) >= 0) {
                 const index: number = this._dynPaintColors.indexOf(this._currentColor);
+                Eterna.observability.recordEvent(`Base:DynPaint:Script${this._dynPaintTools[index].scriptID}`);
                 this._dynPaintTools[index].onPaint(this, seqnum);
             } else if (this._currentColor === RNAPaint.LIBRARY_SELECT && seqnum < this.sequenceLength) {
+                Eterna.observability.recordEvent('Base:LibrarySelect');
                 this.toggleLibrarySelection(seqnum);
                 this._librarySelectionsChanged = true;
             }

--- a/src/eterna/ui/BoosterDialog.ts
+++ b/src/eterna/ui/BoosterDialog.ts
@@ -2,6 +2,7 @@ import Booster from 'eterna/mode/PoseEdit/Booster';
 import PoseEditMode from 'eterna/mode/PoseEdit/PoseEditMode';
 import {BoostersData} from 'eterna/puzzle/Puzzle';
 import {HAlign, VAlign, VLayoutContainer} from 'flashbang';
+import Eterna from 'eterna/Eterna';
 import WindowDialog from './WindowDialog';
 
 export default class BoosterDialog extends WindowDialog<void> {
@@ -25,7 +26,10 @@ export default class BoosterDialog extends WindowDialog<void> {
                 Booster.create(this.mode as PoseEditMode, data).then((booster) => {
                     const button = booster.createButton(14);
                     this.addObject(button, content);
-                    button.clicked.connect(() => { booster.onRun(); });
+                    button.clicked.connect(() => {
+                        booster.onRun();
+                        Eterna.observability.recordEvent(`RunScript:${booster.scriptID}`);
+                    });
                     content.layout();
                     this._window.layout();
                 });

--- a/src/eterna/ui/GameButton.ts
+++ b/src/eterna/ui/GameButton.ts
@@ -75,9 +75,9 @@ export default class GameButton extends Button implements KeyboardListener {
             this._rscriptID = value;
             this._rscriptClickReg.close();
             if (value != null) {
-                this._rscriptClickReg = this.clicked.connect(() => {
+                this._rscriptClickReg = this.regs.add(this.clicked.connect(() => {
                     ROPWait.notifyClickUI(this._rscriptID);
-                });
+                }));
             }
         }
         return this;

--- a/src/eterna/ui/toolbar/Toolbar.ts
+++ b/src/eterna/ui/toolbar/Toolbar.ts
@@ -652,6 +652,9 @@ export default class Toolbar extends ContainerObject {
 
     private setupButton(props: ToolbarParam, enabled: boolean = true): ToolbarButton {
         const button = ToolbarButton.createButton(props);
+        this.regs.add(button.clicked.connect(() => {
+            Eterna.observability.recordEvent(`ToolbarAction:${props.id}`);
+        }));
         if (enabled) {
             this._toolShelf.addButton(button);
             this.setupButtonDrag(button, 'shelf');

--- a/src/eterna/ui/toolbar/ToolbarButton.ts
+++ b/src/eterna/ui/toolbar/ToolbarButton.ts
@@ -7,7 +7,6 @@ import {
     Graphics, Sprite, Texture
 } from 'pixi.js';
 import {Value} from 'signals';
-import Eterna from 'eterna/Eterna';
 import GameButton from '../GameButton';
 
 export const BUTTON_WIDTH = 55;
@@ -135,10 +134,6 @@ export default class ToolbarButton extends GameButton {
         this.regs.add(this.toggled.connectNotify((toggled) => {
             this._arrow.visible = toggled;
             this.drawBackground(toggled);
-        }));
-
-        this.regs.add(this.clicked.connect(() => {
-            Eterna.observability.recordEvent(`ToolbarAction:${this.id}`);
         }));
     }
 

--- a/src/eterna/ui/toolbar/ToolbarButton.ts
+++ b/src/eterna/ui/toolbar/ToolbarButton.ts
@@ -7,6 +7,7 @@ import {
     Graphics, Sprite, Texture
 } from 'pixi.js';
 import {Value} from 'signals';
+import Eterna from 'eterna/Eterna';
 import GameButton from '../GameButton';
 
 export const BUTTON_WIDTH = 55;
@@ -34,6 +35,7 @@ export type ToolbarParam = {
     tooltip:string,
     selectedImg?:string | Texture,
     hotKey?:KeyCode,
+    hotKeyCtrl?: boolean;
     rscriptID?:RScriptUIElementID,
     color?:{color:number, alpha:number},
     toggleColor?:{color:number, alpha:number},
@@ -78,7 +80,7 @@ export default class ToolbarButton extends GameButton {
         this.disabled(info.disableImg);
         if (info.selectedImg) this.selected(info.selectedImg);
         this.tooltip(info.tooltip);
-        if (info.hotKey) this.hotkey(info.hotKey);
+        if (info.hotKey) this.hotkey(info.hotKey, info.hotKeyCtrl);
         if (info.rscriptID) this.rscriptID(info.rscriptID);
 
         if (info.label) {
@@ -133,6 +135,10 @@ export default class ToolbarButton extends GameButton {
         this.regs.add(this.toggled.connectNotify((toggled) => {
             this._arrow.visible = toggled;
             this.drawBackground(toggled);
+        }));
+
+        this.regs.add(this.clicked.connect(() => {
+            Eterna.observability.recordEvent(`RunTool:${this.id}`);
         }));
     }
 

--- a/src/eterna/ui/toolbar/ToolbarButton.ts
+++ b/src/eterna/ui/toolbar/ToolbarButton.ts
@@ -138,7 +138,7 @@ export default class ToolbarButton extends GameButton {
         }));
 
         this.regs.add(this.clicked.connect(() => {
-            Eterna.observability.recordEvent(`RunTool:${this.id}`);
+            Eterna.observability.recordEvent(`ToolbarAction:${this.id}`);
         }));
     }
 

--- a/src/eterna/ui/toolbar/ToolbarButtons.ts
+++ b/src/eterna/ui/toolbar/ToolbarButtons.ts
@@ -358,7 +358,9 @@ export const downloadSVGButtonProps: ToolbarParam = {
     allImg: Bitmaps.ImgDownloadSVG,
     overImg: Bitmaps.ImgOverDownloadSVG,
     disableImg: Bitmaps.ImgGreyDownloadSVG,
-    tooltip: 'Download an SVG of the current custom layout'
+    tooltip: 'Download an SVG of the current custom layout',
+    hotKey: KeyCode.KeyS,
+    hotKeyCtrl: true
 };
 
 export const screenshotButtonProps: ToolbarParam = {

--- a/src/eterna/util/ExternalInterface.ts
+++ b/src/eterna/util/ExternalInterface.ts
@@ -1,6 +1,7 @@
 import log from 'loglevel';
 import {Registration, UnitSignal} from 'signals';
 import {Deferred, Assert} from 'flashbang';
+import Eterna from 'eterna/Eterna';
 
 // We have to deal with callbacks weakly. Ideally there'd be a mechanism to make this a bit
 // more explicit using `unknown`, but I couldn't immediately figure out a way to do it
@@ -17,7 +18,10 @@ export class ExternalInterfaceCtx {
     public readonly changed = new UnitSignal();
 
     public addCallback(name: string, callback: AnyFunction): void {
-        this.callbacks.set(name, callback);
+        this.callbacks.set(name, (...args) => {
+            Eterna.observability.recordEvent(`ScriptFunc:${name}`);
+            callback(...args);
+        });
         this.changed.emit();
     }
 


### PR DESCRIPTION
## Summary
This provides a mechanism for monitoring user behavior, which could be enabled in scenarios such as user studies which are researching effectiveness of new tools or UI changes. This is specifically motivated by an upcoming study on integration of automated solving tools.

## Implementation Notes
* The actions I've instrumented are not necessarily comprehensive, but cover most of the key puzzle solving features. We can always add to this over time/as we identify things we want to instrument
* The "namespacing" of events is hopefully convenient for filtering in/out events that we may want to track in different scenarios (eg specific user tests, or even monitoring via Grafana/Mimir), but this may need tweaking
* I've restored move tracking and merged it with this system under the `Move` namespace. The logic is largely unchanged from what was shown in commit f06f1727984b8c951672f6e455de6c879af683e2, with the exception of the reporting mechanism and paste having been moved into GameMode (we now treat this as a paste move rather than a set of muations!)
* The ObservabilityReporter abstraction admittedly looks a little excessive right now, but there was some rationale here. With this in place, it becomes trivial to have two different sets of reports, each of differing lifetimes, filtering a different set of events, going to different places. For example, For this user study, we want user interaction and moveset events for a given puzzle to be sent via postmessage to Qualtrics, at some different point we may want to, say, send all script execution events to Mimir over the entire app lifetime (including as the puzzle changes) to have an indication of what scripts and what script APIs are actively in use to ensure compatibility, and we could even use this same mechanism to store movesets like we used to for an individual puzzle.
* I made a couple of drive-by cleanups: a couple missing signal registrations in PoseEdit, and tying the download keyboard shortcut into the toolbar button

## Testing
* Some basic unit tests
* Enabled ConsoleReporter, clicked a couple buttons (mutated bases, swap in hotbar and extended toolbar, change folder and marker layer)
