### PR TITLE
Fix state numbers in constraints, add to energy constraint

### DIFF
--- a/src/eterna/constraints/ConstraintBox.ts
+++ b/src/eterna/constraints/ConstraintBox.ts
@@ -85,7 +85,7 @@ export default class ConstraintBox extends ContainerObject implements Enableable
 
         this._stateText = Fonts.std('', 18).bold().color(0xffffff).letterSpacing(-0.5)
             .build();
-        this._stateText.position.set(3, 45);
+        this._stateText.position.set(5, 45);
         this._stateText.visible = false;
         this.container.addChild(this._stateText);
 
@@ -235,7 +235,7 @@ export default class ConstraintBox extends ContainerObject implements Enableable
             this.initOpaqueBackdrop(this._bg.texture.width, this._bg.texture.height);
             this._check.position.set(55, 50);
             this._noText.position.set(35, 1);
-            this._stateText.position.set(3, 45);
+            this._stateText.position.set(5, 45);
         }
 
         if (this._forMissionScreen) {

--- a/src/eterna/constraints/constraints/EnergyConstraint.ts
+++ b/src/eterna/constraints/constraints/EnergyConstraint.ts
@@ -11,6 +11,7 @@ import Constraint, {BaseConstraintStatus, ConstraintContext} from '../Constraint
 
 interface EnergyConstraintStatus extends BaseConstraintStatus {
     energy: number;
+    states: number;
 }
 
 abstract class EnergyConstraint extends Constraint<EnergyConstraintStatus> {
@@ -34,7 +35,8 @@ abstract class EnergyConstraint extends Constraint<EnergyConstraintStatus> {
 
         return {
             satisfied: this.mode === 'max' ? energy <= this.energy : energy >= this.energy,
-            energy
+            energy,
+            states: context.undoBlocks.length
         };
     }
 
@@ -50,6 +52,10 @@ abstract class EnergyConstraint extends Constraint<EnergyConstraintStatus> {
             ? ConstraintBox.createTextStyle().append(`The free energy must be below ${this.energy} kcal`)
             : ConstraintBox.createTextStyle().append(`The free energy must be above ${this.energy} kcal`);
 
+        if (status.states > 1) {
+            tooltip.append(` in state ${this.state + 1}`);
+        }
+
         return {
             satisfied: status.satisfied,
             tooltip,
@@ -57,7 +63,8 @@ abstract class EnergyConstraint extends Constraint<EnergyConstraintStatus> {
             icon: EnergyConstraint._icon,
             showOutline: true,
             statText,
-            clarificationText: `AT ${this.mode === 'max' ? 'MOST' : 'LEAST'}${this.energy.toString().length > 2 ? ' \n' : ' '}${this.energy} KCAL`
+            clarificationText: `AT ${this.mode === 'max' ? 'MOST' : 'LEAST'}${this.energy.toString().length > 2 ? ' \n' : ' '}${this.energy} KCAL`,
+            stateNumber: this.state + 1
         };
     }
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -832,7 +832,7 @@ export default class PoseEditMode extends GameMode {
         // Set up the constraintBar
         this._constraintBar = new ConstraintBar(
             this._puzzle.constraints,
-            this._puzzle.getSecstructs.length
+            this._puzzle.getSecstructs().length
         );
         this._constraintBar.display.visible = false;
         this.addObject(this._constraintBar, this._constraintsLayer);


### PR DESCRIPTION
## Summary
Previously a bug prevented state numbers from being shown in constraints that apply to different states, such as SHAPE and BINDINGS constraints. Additionally, we add support for this to energy constraints.

## Testing
Test puzzle with energy constraints, ensured state numbers showed as intended

