### PR TITLE
Make mutation markers the default layer when a mutation constraint is active

### DIFF
--- a/src/eterna/constraints/constraints/MutationConstraint.ts
+++ b/src/eterna/constraints/constraints/MutationConstraint.ts
@@ -12,7 +12,7 @@ interface MutationConstraintStatus extends BaseConstraintStatus {
     mutations: number;
 }
 
-abstract class MutationConstraint extends Constraint<MutationConstraintStatus> {
+export abstract class MutationConstraint extends Constraint<MutationConstraintStatus> {
     public readonly mutations: number;
     public readonly mode: 'min' | 'max';
 

--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -91,6 +91,7 @@ import TLoopConstraint, {TLoopSeqB, TLoopSeqA, TLoopPairs} from 'eterna/constrai
 import FoldingAPI from 'eterna/eternaScript/FoldingAPI';
 import PostMessageReporter from 'eterna/observability/PostMessageReporter';
 import TimerConstraint from 'eterna/constraints/constraints/TimerConstraint';
+import {MutationConstraint} from 'eterna/constraints/constraints/MutationConstraint';
 import GameMode from '../GameMode';
 import SubmittingDialog from './SubmittingDialog';
 import SubmitPoseDialog from './SubmitPoseDialog';
@@ -892,7 +893,10 @@ export default class PoseEditMode extends GameMode {
             // there's a good chance players may care about seeing mutations from the starting
             // sequence, so we'll add a layer to handle that
             this._shouldMarkMutations = true;
-            this.addMarkerLayer(MUTATION_MARKER_LAYER, false);
+            const setAsDefault = this._puzzle.constraints?.some(
+                (constraint) => constraint instanceof MutationConstraint
+            );
+            this.addMarkerLayer(MUTATION_MARKER_LAYER, setAsDefault);
         }
 
         // Load elements from targetConditions into poses.


### PR DESCRIPTION
## Summary
If a script constraint adds a custom marker layer, that marker will be switched to be the default when its added. However, we did not do the same for mutations. We now do so in the case a mutation constraint is present

## Implementation Notes
This was discussed in a team meeting and determined to be desirable behavior. If no mutation constraint is active, tracking mutations might be interesting (hence we still add the layer) but it is not an intended mechanic of the puzzle. However because the user actively needs to keep track of this when a mutation constraint is present, it makes sense to have this be the default mode.

## Testing
Tested puzzle with and without mutation constraint, does or does not set the default layer as desired
