### PR TITLE
Reposition barcode region in reverse-complement states

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -921,9 +921,6 @@ export default class PoseEditMode extends GameMode {
 
             Assert.assertIsDefined(seq);
             this._poses[ii].sequence = this._puzzle.transformSequence(seq, ii, 0);
-            if (this._puzzle.barcodeIndices != null) {
-                this._poses[ii].barcodes = this._puzzle.barcodeIndices;
-            }
             this._poses[ii].setOligos(this._targetOligos[ii], this._targetOligosOrder[ii]);
             this._poses[ii].setOligo(
                 this._targetOligo[ii],
@@ -1521,7 +1518,7 @@ export default class PoseEditMode extends GameMode {
         );
         scriptInterfaceCtx.addCallback(
             'get_barcode_indices',
-            lockDuringFold((): number[] | null => this._puzzle.barcodeIndices)
+            lockDuringFold((): number[] | null => this._puzzle.getBarcodeIndices(0))
         );
         scriptInterfaceCtx.addCallback(
             'is_barcode_available',
@@ -2145,6 +2142,11 @@ export default class PoseEditMode extends GameMode {
                 this.getCurrentUndoBlock(targetIndex).sequence, targetIndex, targetIndex
             );
             const tcType: TargetType = tc['type'];
+
+            const barcode = this._puzzle.getBarcodeIndices(targetIndex);
+            if (barcode) {
+                this._poses[poseIndex].barcodes = barcode;
+            }
 
             if (tcType === 'multistrand') {
                 if (tc['oligos'] !== undefined) {
@@ -3429,6 +3431,11 @@ export default class PoseEditMode extends GameMode {
             if (this._targetConditions == null || this._targetConditions[stateIdx] === undefined
                 || (this._targetConditions[stateIdx] as TargetConditions)['type'] === undefined) {
                 continue;
+            }
+
+            const barcode = this._puzzle.getBarcodeIndices(stateIdx);
+            if (barcode) {
+                this._poses[poseIdx].barcodes = barcode;
             }
 
             const tc = this._targetConditions[stateIdx] as TargetConditions;

--- a/src/eterna/puzzle/Puzzle.ts
+++ b/src/eterna/puzzle/Puzzle.ts
@@ -417,7 +417,7 @@ export default class Puzzle {
         this._barcodeLength = length;
     }
 
-    public get barcodeIndices(): number[] | null {
+    public getBarcodeIndices(targetIndex: number): number[] | null {
         if (!this._useBarcode) {
             return null;
         }
@@ -438,11 +438,15 @@ export default class Puzzle {
             barcodeStart = secstruct.length - barcodeLength;
         }
 
-        return Utility.range(barcodeStart, barcodeStart + barcodeLength);
+        if (this._targetConditions?.[targetIndex].reverseComplement) {
+            return Utility.range(secstruct.length - (barcodeStart + barcodeLength), secstruct.length - barcodeStart);
+        } else {
+            return Utility.range(barcodeStart, barcodeStart + barcodeLength);
+        }
     }
 
     public getBarcodeHairpin(seq: Sequence): Sequence {
-        const barcode = this.barcodeIndices;
+        const barcode = this.getBarcodeIndices(0);
         if (!barcode) {
             throw new Error('Can\'t determine barcode hairpin for a puzzle that doesn\'t use barcodes');
         }

--- a/src/eterna/puzzle/__tests__/Puzzle.test.ts
+++ b/src/eterna/puzzle/__tests__/Puzzle.test.ts
@@ -14,7 +14,7 @@ describe('Puzzle#barcodeIndices', () => {
         puz.useBarcode = true;
         puz.barcodeStart = 10;
         puz.secstructs = ['.'.repeat(50)];
-        expect(puz.barcodeIndices).toEqual([10, 11, 12, 13, 14, 15, 16]);
+        expect(puz.getBarcodeIndices(0)).toEqual([10, 11, 12, 13, 14, 15, 16]);
     });
 
     it('should return the 7 bases prior to the tail if tails are enabled', () => {
@@ -24,14 +24,14 @@ describe('Puzzle#barcodeIndices', () => {
         // There will be 5 extra bases added to the front and 20 added to the end,
         // so our puzzle will actually be 75 bases long instead of 50
         puz.setUseTails(true, false);
-        expect(puz.barcodeIndices).toEqual([47, 48, 49, 50, 51, 52, 53]);
+        expect(puz.getBarcodeIndices(0)).toEqual([47, 48, 49, 50, 51, 52, 53]);
     });
 
     it('should return the last 7 bases if neither barcode start or tails are specified', () => {
         const puz = new Puzzle(0, 'puzzle', PuzzleType.EXPERIMENTAL, 'author');
         puz.useBarcode = true;
         puz.secstructs = ['.'.repeat(50)];
-        expect(puz.barcodeIndices).toEqual([43, 44, 45, 46, 47, 48, 49]);
+        expect(puz.getBarcodeIndices(0)).toEqual([43, 44, 45, 46, 47, 48, 49]);
     });
 
     it('should prefer the barcode start field over the use tails value', () => {
@@ -40,7 +40,7 @@ describe('Puzzle#barcodeIndices', () => {
         puz.barcodeStart = 10;
         puz.secstructs = ['.'.repeat(50)];
         puz.setUseTails(true, false);
-        expect(puz.barcodeIndices).toEqual([10, 11, 12, 13, 14, 15, 16]);
+        expect(puz.getBarcodeIndices(0)).toEqual([10, 11, 12, 13, 14, 15, 16]);
     });
 });
 


### PR DESCRIPTION
## Summary
When a state displays the reverse complement of a sequence, the barcode is now displayed on the opposite end of the strand

## Implementation Notes
Eg since when modifying the last 3 bases, the first three bases are what are modified in the reverse complement, so that's
what really refers to the same region of the strand. We discussed whether the barcode region should instead be removed
entirely (as it probably isn't really the barcode any more in the reverse complement), but we determined this would
make more sense and allow users to better orient themselves

## Testing
Validated barcode positioning on puzzle with states with and without reverse complement. Verified it was correctly positioned across
changes in state, target/natural, pip, etc
