### PR TITLE
Fix edge case in custom layout motification detection

### DIFF
--- a/src/eterna/pose2D/Pose2D.ts
+++ b/src/eterna/pose2D/Pose2D.ts
@@ -2615,7 +2615,7 @@ export default class Pose2D extends ContainerObject implements Updatable {
         } else {
             let diff = false;
             for (let ii = 0; ii < setting.length; ++ii) {
-                if (setting[ii] !== this._customLayout?.[ii] ?? null) {
+                if (setting[ii] !== (this._customLayout?.[ii] ?? null)) {
                     diff = true;
                     break;
                 }


### PR DESCRIPTION
Order of operations issue, caught by newer typescript version in vs code (and so we now no longer have the ts error being shown in the editor). As far as I can tell this just meant if moving from no custom layout being visualized to one with all nulls, we would unnecessarily trigger a rerender. Which... doesnt really matter. But now we fix the typecheck!
