### PR TITLE
Fix positioning of locks in pip mode

### DIFF
--- a/src/eterna/mode/PoseEdit/PoseEditMode.ts
+++ b/src/eterna/mode/PoseEdit/PoseEditMode.ts
@@ -2135,7 +2135,7 @@ export default class PoseEditMode extends GameMode {
             );
             const locks = this.getCurrentUndoBlock(targetIndex).puzzleLocks;
             if (locks) {
-                this._poses[0].puzzleLocks = this.transformBaseMap(locks, targetIndex, targetIndex, true);
+                this._poses[poseIndex].puzzleLocks = this.transformBaseMap(locks, targetIndex, targetIndex, true);
             }
             const tcType: TargetType = tc['type'];
 


### PR DESCRIPTION
We always updated the lock position on the first view, instead of on the view we actually intended to update. Probably a copy-paste bug
