### PR TITLE
Fix base highlights not showing when the first base is highlighted

### DIFF
--- a/src/eterna/mode/GameMode.ts
+++ b/src/eterna/mode/GameMode.ts
@@ -847,7 +847,7 @@ export default abstract class GameMode extends AppMode {
         const ret: number[] = [];
         while (true) {
             const next = allIndices.shift();
-            if (!next) break;
+            if (next === undefined) break;
 
             const last = ret[ret.length - 1];
             if (last === next - 1) ret[ret.length - 1] = next;


### PR DESCRIPTION
We had a "falsy" check to see when we finished going through all bases, but we needed to check if shift() was returning undefined specifically, as base 0 is also falsy (thus causing an early abort)