### PR TITLE
Fix crash when hovering over sparks in 3D view

### DIFF
--- a/src/eterna/pose3D/Pose3DDialog.ts
+++ b/src/eterna/pose3D/Pose3DDialog.ts
@@ -200,8 +200,10 @@ export default class Pose3DDialog extends WindowDialog<void> {
                 // think that because the highlight is the first thing behind the cursor, that we're
                 // hovering over that and not the base
                 this._baseHighlights.visible = false;
+                this._sparkGroup.visible = false;
                 nglRender(true);
                 this._baseHighlights.visible = true;
+                this._sparkGroup.visible = true;
             } else {
                 this._composer.render();
 


### PR DESCRIPTION
We need to omit the sparks from the hit-testing render pass, so when `pick` is called from a hover, the hit-testing doesn't grab an invalid object